### PR TITLE
fix(cert-manager-webhook-ovh): adds required configVersion

### DIFF
--- a/cluster-home/core/certificates/cert-manager-webhook-ovh-app.yaml
+++ b/cluster-home/core/certificates/cert-manager-webhook-ovh-app.yaml
@@ -13,6 +13,7 @@ spec:
     helm:
       version: v3
       values: |
+        configVersion: 0.0.1
         groupName: acme.szamszur.cloud
         issuers:
           - name: letsencrypt


### PR DESCRIPTION
https://aureq.github.io/cert-manager-webhook-ovh/#configuration

> configVersion The config version is used each time a breaking changes introduced in values.yaml to prevent broken deployments. To retrieve the latest values.yaml which contains the updated configuration and the correct config version, run helm show values