### PR TITLE
chore: bumps ingress-controller from 1.8.2 to 1.12.1

### DIFF
--- a/cluster-home/core/ingress-controller/kustomization.yaml
+++ b/cluster-home/core/ingress-controller/kustomization.yaml
@@ -3,8 +3,8 @@ kind: Kustomization
 namespace: ingress-nginx
 
 resources:
-# renovate: datasource=github-releases depName=kubernetes/ingress-nginx
-- https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.8.2/deploy/static/provider/baremetal/deploy.yaml
+# renovate: datasource=github-releases depName=controller repository=https://github.com/kubernetes/ingress-nginx
+- https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.12.1/deploy/static/provider/baremetal/deploy.yaml
 
 patches:
   - target:


### PR DESCRIPTION
https://kubernetes.io/blog/2025/03/24/ingress-nginx-cve-2025-1974/