### PR TITLE
Feat/implement proxmox tf modules

### DIFF
--- a/terraform/proxmox/acme/.terraform.lock.hcl
+++ b/terraform/proxmox/acme/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/bpg/proxmox" {
+  version     = "0.76.1"
+  constraints = "0.76.1"
+  hashes = [
+    "h1:0yFjPKRsNyv14JD50VC6DUudG2vej0NG8uiBA+XfKRI=",
+    "zh:0c0f59d027eb7090e81b92f34ed27c2467c4e03f1e58128372229457f761418a",
+    "zh:4045ca7307abd453373079637c9b15d5972d32fc1e2ab69b635bf3a74dc1032c",
+    "zh:58d0e2d0bd22eb95aa3ee30c7dd6e3cc0986c703ca90cf402fc7634fbb665330",
+    "zh:5aa2058013abbae0c426c110f723a5d3c8d0407ede15616c0151bca8655aaa09",
+    "zh:5e991da91b42bc4912be381f5970a5074538f721dd0fb746947bdf2041821cb1",
+    "zh:62914bb9857802c895fc48144cd8e37c4ef31d01e5c2b8e012ef5f2aad05b8bf",
+    "zh:a55800caab94e20bef1f928e2486d556114f00a1fb67cbd87c26b61025637427",
+    "zh:a6173cd06104d31b6d5327af4ed6e8e10e823870684c2e26dfd5d19e34addc08",
+    "zh:b35bf59f0259744a39fce5e8585f9d28aea017ba30298afa75069563ec13baa8",
+    "zh:bb4fb5f1b282dcd0f71f67edf270d0c35dab844723fcfeef487402950657cedd",
+    "zh:bcc6a4868931272f92b672952ed3b500d0eb68955f4fd3b57a4e2b1de2691176",
+    "zh:ce94d971748676c063d9f7ede2df2911e5bdcd37f6855778a5e61e79890c4204",
+    "zh:ea94593a43dd2dcec04f09cdf7a0376c1843053ae87903056a1a8db5adc1b24c",
+    "zh:f0057c3a50ef93f5ccfb2a1abf672281bc8d9a082ff8ab298f7c0ce5aa077136",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+  ]
+}

--- a/terraform/proxmox/acme/README.md
+++ b/terraform/proxmox/acme/README.md
@@ -1,0 +1,11 @@
+# Terraform: Proxmox ACME module
+
+This Terraform module provisions and manages both a Let's Encrypt ACME account and the OVH DSN01 ACME plugin.
+
+## Import state
+
+```shell
+terraform init
+terraform import proxmox_virtual_environment_acme_account.letsencrypt letsencrypt
+terraform import proxmox_virtual_environment_acme_dns_plugin.acme-ovh ACME-OVH
+```

--- a/terraform/proxmox/acme/auth.tf
+++ b/terraform/proxmox/acme/auth.tf
@@ -1,0 +1,6 @@
+provider "proxmox" {
+  endpoint  = "https://${var.proxmox_host}:8006/"
+  insecure  = true
+  username  = "root@pam"
+  password  = var.proxmox_root_password
+}

--- a/terraform/proxmox/acme/main.tf
+++ b/terraform/proxmox/acme/main.tf
@@ -1,0 +1,17 @@
+resource "proxmox_virtual_environment_acme_account" "letsencrypt" {
+  name      = "letsencrypt"
+  contact   = "acme@szamszur.cloud"
+  directory = "https://acme-v02.api.letsencrypt.org/directory"
+  tos       = "https://letsencrypt.org/documents/LE-SA-v1.5-February-24-2025.pdf"
+}
+
+resource "proxmox_virtual_environment_acme_dns_plugin" "acme-ovh" {
+  plugin = "ACME-OVH"
+  api    = "OVH"
+  data = {
+    OVH_AK = var.ovh_application_key
+    OVH_AS = var.ovh_application_secret
+    OVH_CK = var.ovh_consumer_key
+    OVH_END_POINT = "ovh-eu"
+  }
+}

--- a/terraform/proxmox/acme/secrets.auto.tfvars.age
+++ b/terraform/proxmox/acme/secrets.auto.tfvars.age
@@ -1,0 +1,5 @@
+age-encryption.org/v1
+-> X25519 3lQQ9W4bAc8oxdqEbtTTywaQxyghbS2uVXF+YJ6/WGA
+IFNApVFBpkzOnFNdc3drbIOxa0CB/ZgCiKeKg90ot/E
+--- 62ftXCkLtc+kyr1doAnmn5pD61B2g/vWnsybcjD1yEg
+Ûpž|´*m†Ì7…zÒy˜HµÀHk>—‚ò'pQp¬W.ÄIŒ™;Ø9˜³ìÁÿbd™—{Nïä‰Qè>+ÚØRœƒ×}@–¶ƒxßçµ’ÐŠ½=£{=§¸mƒŒ{ŒU·6Û6mcÄ“TPEy¿©ÁÏ~ïx´GéÊ¢ãr›bûxQÅ5 ånÂ¡¤Ö<É†iççŒJ¬b OfË`áô+&t)Òä‚°Š×$àÓú¬¿Ã’™hÎ+ƒe3

--- a/terraform/proxmox/acme/terraform.tf
+++ b/terraform/proxmox/acme/terraform.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "kubernetes" {
+    secret_suffix    = "proxmox.acme"
+    config_path      = "~/.kube/config"
+    namespace = "terraform"
+  }
+}

--- a/terraform/proxmox/acme/variables.tf
+++ b/terraform/proxmox/acme/variables.tf
@@ -1,0 +1,29 @@
+variable "proxmox_host" {
+  description = "Proxmox host"
+  type        = string
+  default     = "192.168.10.11"
+}
+
+variable "proxmox_root_password" {
+  description = "Proxmox root@pam password"
+  type        = string
+  sensitive   = true
+}
+
+variable "ovh_application_key" {
+  description = "OVH application key"
+  type        = string
+  sensitive   = true
+}
+
+variable "ovh_application_secret" {
+  description = "OVH application secret"
+  type        = string
+  sensitive   = true
+}
+
+variable "ovh_consumer_key" {
+  description = "OVH consumer key"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/proxmox/acme/versions.tf
+++ b/terraform/proxmox/acme/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    proxmox = {
+      source  = "bpg/proxmox"
+      version = "0.76.1"
+    }
+  }
+  required_version = ">= 1.5"
+}

--- a/terraform/proxmox/network/.terraform.lock.hcl
+++ b/terraform/proxmox/network/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/bpg/proxmox" {
+  version     = "0.76.1"
+  constraints = "0.76.1"
+  hashes = [
+    "h1:0yFjPKRsNyv14JD50VC6DUudG2vej0NG8uiBA+XfKRI=",
+    "zh:0c0f59d027eb7090e81b92f34ed27c2467c4e03f1e58128372229457f761418a",
+    "zh:4045ca7307abd453373079637c9b15d5972d32fc1e2ab69b635bf3a74dc1032c",
+    "zh:58d0e2d0bd22eb95aa3ee30c7dd6e3cc0986c703ca90cf402fc7634fbb665330",
+    "zh:5aa2058013abbae0c426c110f723a5d3c8d0407ede15616c0151bca8655aaa09",
+    "zh:5e991da91b42bc4912be381f5970a5074538f721dd0fb746947bdf2041821cb1",
+    "zh:62914bb9857802c895fc48144cd8e37c4ef31d01e5c2b8e012ef5f2aad05b8bf",
+    "zh:a55800caab94e20bef1f928e2486d556114f00a1fb67cbd87c26b61025637427",
+    "zh:a6173cd06104d31b6d5327af4ed6e8e10e823870684c2e26dfd5d19e34addc08",
+    "zh:b35bf59f0259744a39fce5e8585f9d28aea017ba30298afa75069563ec13baa8",
+    "zh:bb4fb5f1b282dcd0f71f67edf270d0c35dab844723fcfeef487402950657cedd",
+    "zh:bcc6a4868931272f92b672952ed3b500d0eb68955f4fd3b57a4e2b1de2691176",
+    "zh:ce94d971748676c063d9f7ede2df2911e5bdcd37f6855778a5e61e79890c4204",
+    "zh:ea94593a43dd2dcec04f09cdf7a0376c1843053ae87903056a1a8db5adc1b24c",
+    "zh:f0057c3a50ef93f5ccfb2a1abf672281bc8d9a082ff8ab298f7c0ce5aa077136",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+  ]
+}

--- a/terraform/proxmox/network/README.md
+++ b/terraform/proxmox/network/README.md
@@ -1,0 +1,13 @@
+# Terraform: Proxmox network module
+
+This Terraform module manages NICs and Linux bridges across all Proxmox nodes in a cluster.
+
+## Import state
+
+```shell
+terraform init
+terraform import proxmox_virtual_environment_network_linux_bridge.pve-r740xd_vmbr0 pve-r740xd:vmbr0
+terraform import proxmox_virtual_environment_network_linux_bridge.pve-r740xd_vmbr1 pve-r740xd:vmbr1
+terraform import proxmox_virtual_environment_network_linux_bridge.pve-t630_vmbr0 pve-t630:vmbr0
+terraform import proxmox_virtual_environment_network_linux_bridge.pve-t630_vmbr1 pve-t630:vmbr1
+```

--- a/terraform/proxmox/network/auth.tf
+++ b/terraform/proxmox/network/auth.tf
@@ -1,0 +1,5 @@
+provider "proxmox" {
+  endpoint  = "https://${var.proxmox_host}:8006/"
+  insecure  = true
+  api_token = "${var.proxmox_token_id}=${var.proxmox_token_secret}"
+}

--- a/terraform/proxmox/network/main.tf
+++ b/terraform/proxmox/network/main.tf
@@ -1,0 +1,51 @@
+resource "proxmox_virtual_environment_network_linux_bridge" "pve-r740xd_vmbr0" {
+  node_name = "pve-r740xd"
+  name      = "vmbr0"
+
+  address = "192.168.10.11/24"
+  gateway = "192.168.10.1"
+  vlan_aware = false
+  comment = "Bridge for host. Native VLAN: management. Managed by terraform"
+
+  ports = [
+    "eno3"
+  ]
+}
+
+resource "proxmox_virtual_environment_network_linux_bridge" "pve-r740xd_vmbr1" {
+  node_name = "pve-r740xd"
+  name      = "vmbr1"
+
+  vlan_aware = true
+  comment = "Bridge for VMs. Native VLAN: servers. Managed by terraform"
+
+  ports = [
+    "eno1np0"
+  ]
+}
+
+resource "proxmox_virtual_environment_network_linux_bridge" "pve-t630_vmbr0" {
+  node_name = "pve-t630"
+  name      = "vmbr0"
+
+  address = "192.168.10.10/24"
+  gateway = "192.168.10.1"
+  vlan_aware = true
+  comment = "Bridge for host. Native VLAN: management. Managed by terraform"
+
+  ports = [
+    "bond0"
+  ]
+}
+
+resource "proxmox_virtual_environment_network_linux_bridge" "pve-t630_vmbr1" {
+  node_name = "pve-t630"
+  name      = "vmbr1"
+
+  vlan_aware = true
+  comment = "Bridge for VMs. Native VLAN: servers. Managed by terraform"
+
+  ports = [
+    "enp129s0f0"
+  ]
+}

--- a/terraform/proxmox/network/secrets.auto.tfvars.age
+++ b/terraform/proxmox/network/secrets.auto.tfvars.age
@@ -1,0 +1,6 @@
+age-encryption.org/v1
+-> X25519 5eKNhyFt9a5oxPS+k3nGwzThmEKYhDFqLEnuxOZhdmk
+emeKv4eq0hh0DUkw883eTbI85nyI3wVR1A1hzuQD4kg
+--- NanE1W4BNNnaGPAQHJmkU163Qu3yYMZNjQu9fcyZT6w
+q³/ΟΡGzζφς“«;Ok4Υ/σ7:σE®‡ΜΦwÿ ωl°®	
+ψ¥’ώ®oΘWίf-β’ΤMάA¬ιή6[Gβ‘νεX|¬°ιπ―'ΚµΪΖcbΌΜ¨ΒΜοςΥτwζ)™¥CςυL¦·ΈV―°GλΚOµ/Α.S3

--- a/terraform/proxmox/network/terraform.tf
+++ b/terraform/proxmox/network/terraform.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "kubernetes" {
+    secret_suffix    = "proxmox.network"
+    config_path      = "~/.kube/config"
+    namespace = "terraform"
+  }
+}

--- a/terraform/proxmox/network/variables.tf
+++ b/terraform/proxmox/network/variables.tf
@@ -1,0 +1,17 @@
+variable "proxmox_host" {
+  description = "Proxmox host"
+  type        = string
+  default     = "192.168.10.11"
+}
+
+variable "proxmox_token_id" {
+  description = "Proxmox token id"
+  type        = string
+}
+
+variable "proxmox_token_secret" {
+  description = "Proxmox token secret"
+  type        = string
+  sensitive   = true
+}
+

--- a/terraform/proxmox/network/versions.tf
+++ b/terraform/proxmox/network/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    proxmox = {
+      source  = "bpg/proxmox"
+      version = "0.76.1"
+    }
+  }
+  required_version = ">= 1.5"
+}

--- a/terraform/proxmox/repos/.terraform.lock.hcl
+++ b/terraform/proxmox/repos/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/bpg/proxmox" {
+  version     = "0.76.1"
+  constraints = "0.76.1"
+  hashes = [
+    "h1:0yFjPKRsNyv14JD50VC6DUudG2vej0NG8uiBA+XfKRI=",
+    "zh:0c0f59d027eb7090e81b92f34ed27c2467c4e03f1e58128372229457f761418a",
+    "zh:4045ca7307abd453373079637c9b15d5972d32fc1e2ab69b635bf3a74dc1032c",
+    "zh:58d0e2d0bd22eb95aa3ee30c7dd6e3cc0986c703ca90cf402fc7634fbb665330",
+    "zh:5aa2058013abbae0c426c110f723a5d3c8d0407ede15616c0151bca8655aaa09",
+    "zh:5e991da91b42bc4912be381f5970a5074538f721dd0fb746947bdf2041821cb1",
+    "zh:62914bb9857802c895fc48144cd8e37c4ef31d01e5c2b8e012ef5f2aad05b8bf",
+    "zh:a55800caab94e20bef1f928e2486d556114f00a1fb67cbd87c26b61025637427",
+    "zh:a6173cd06104d31b6d5327af4ed6e8e10e823870684c2e26dfd5d19e34addc08",
+    "zh:b35bf59f0259744a39fce5e8585f9d28aea017ba30298afa75069563ec13baa8",
+    "zh:bb4fb5f1b282dcd0f71f67edf270d0c35dab844723fcfeef487402950657cedd",
+    "zh:bcc6a4868931272f92b672952ed3b500d0eb68955f4fd3b57a4e2b1de2691176",
+    "zh:ce94d971748676c063d9f7ede2df2911e5bdcd37f6855778a5e61e79890c4204",
+    "zh:ea94593a43dd2dcec04f09cdf7a0376c1843053ae87903056a1a8db5adc1b24c",
+    "zh:f0057c3a50ef93f5ccfb2a1abf672281bc8d9a082ff8ab298f7c0ce5aa077136",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+  ]
+}

--- a/terraform/proxmox/repos/README.md
+++ b/terraform/proxmox/repos/README.md
@@ -1,0 +1,23 @@
+# Terraform: Proxmox APT repositories module
+
+This Terraform module manages Proxmox host APT repositories across all Proxmox nodes in a cluster.
+
+## Import state
+
+```shell
+terraform init
+
+terraform import proxmox_virtual_environment_apt_standard_repository.no-subscription[\"pve-t630\"] pve-t630,no-subscription
+terraform import proxmox_virtual_environment_apt_standard_repository.enterprise[\"pve-t630\"] pve-t630,enterprise
+terraform import proxmox_virtual_environment_apt_standard_repository.ceph-reef-no-subscription[\"pve-t630\"] pve-t630,ceph-reef-no-subscription
+terraform import proxmox_virtual_environment_apt_repository.no-subscription[\"pve-t630\"] pve-t630,/etc/apt/sources.list,3
+terraform import proxmox_virtual_environment_apt_repository.enterprise[\"pve-t630\"] pve-t630,/etc/apt/sources.list.d/pve-enterprise.list,0
+terraform import proxmox_virtual_environment_apt_repository.ceph-reef-no-subscription[\"pve-t630\"] pve-t630,/etc/apt/sources.list.d/ceph.list,0
+
+terraform import proxmox_virtual_environment_apt_standard_repository.no-subscription[\"pve-r740xd\"] pve-r740xd,no-subscription
+terraform import proxmox_virtual_environment_apt_standard_repository.enterprise[\"pve-r740xd\"] pve-r740xd,enterprise
+terraform import proxmox_virtual_environment_apt_standard_repository.ceph-reef-no-subscription[\"pve-r740xd\"] pve-r740xd,ceph-reef-no-subscription
+terraform import proxmox_virtual_environment_apt_repository.no-subscription[\"pve-r740xd\"] pve-r740xd,/etc/apt/sources.list,3
+terraform import proxmox_virtual_environment_apt_repository.enterprise[\"pve-r740xd\"] pve-r740xd,/etc/apt/sources.list.d/pve-enterprise.list,0
+terraform import proxmox_virtual_environment_apt_repository.ceph-reef-no-subscription[\"pve-r740xd\"] pve-r740xd,/etc/apt/sources.list.d/ceph.list,0
+```

--- a/terraform/proxmox/repos/auth.tf
+++ b/terraform/proxmox/repos/auth.tf
@@ -1,0 +1,5 @@
+provider "proxmox" {
+  endpoint  = "https://${var.proxmox_host}:8006/"
+  insecure  = true
+  api_token = "${var.proxmox_token_id}=${var.proxmox_token_secret}"
+}

--- a/terraform/proxmox/repos/main.tf
+++ b/terraform/proxmox/repos/main.tf
@@ -1,0 +1,41 @@
+resource "proxmox_virtual_environment_apt_standard_repository" "no-subscription" {
+  for_each  = var.proxmox_nodes
+  handle = "no-subscription"
+  node   = each.value
+}
+
+resource "proxmox_virtual_environment_apt_standard_repository" "enterprise" {
+  for_each  = var.proxmox_nodes
+  handle = "enterprise"
+  node   = each.value
+}
+
+resource "proxmox_virtual_environment_apt_standard_repository" "ceph-reef-no-subscription" {
+  for_each  = var.proxmox_nodes
+  handle = "ceph-reef-no-subscription"
+  node   = each.value
+}
+
+resource "proxmox_virtual_environment_apt_repository" "no-subscription" {
+  for_each  = var.proxmox_nodes
+  enabled   = true
+  file_path = proxmox_virtual_environment_apt_standard_repository.no-subscription[each.value].file_path
+  index     = proxmox_virtual_environment_apt_standard_repository.no-subscription[each.value].index
+  node      = proxmox_virtual_environment_apt_standard_repository.no-subscription[each.value].node
+}
+
+resource "proxmox_virtual_environment_apt_repository" "enterprise" {
+  for_each  = var.proxmox_nodes
+  enabled   = false
+  file_path = proxmox_virtual_environment_apt_standard_repository.enterprise[each.value].file_path
+  index     = proxmox_virtual_environment_apt_standard_repository.enterprise[each.value].index
+  node      = proxmox_virtual_environment_apt_standard_repository.enterprise[each.value].node
+}
+
+resource "proxmox_virtual_environment_apt_repository" "ceph-reef-no-subscription" {
+  for_each  = var.proxmox_nodes
+  enabled   = true
+  file_path = proxmox_virtual_environment_apt_standard_repository.ceph-reef-no-subscription[each.value].file_path
+  index     = proxmox_virtual_environment_apt_standard_repository.ceph-reef-no-subscription[each.value].index
+  node      = proxmox_virtual_environment_apt_standard_repository.ceph-reef-no-subscription[each.value].node
+}

--- a/terraform/proxmox/repos/secrets.auto.tfvars.age
+++ b/terraform/proxmox/repos/secrets.auto.tfvars.age
@@ -1,0 +1,6 @@
+age-encryption.org/v1
+-> X25519 5eKNhyFt9a5oxPS+k3nGwzThmEKYhDFqLEnuxOZhdmk
+emeKv4eq0hh0DUkw883eTbI85nyI3wVR1A1hzuQD4kg
+--- NanE1W4BNNnaGPAQHJmkU163Qu3yYMZNjQu9fcyZT6w
+q³/ΟΡGzζφς“«;Ok4Υ/σ7:σE®‡ΜΦwÿ ωl°®	
+ψ¥’ώ®oΘWίf-β’ΤMάA¬ιή6[Gβ‘νεX|¬°ιπ―'ΚµΪΖcbΌΜ¨ΒΜοςΥτwζ)™¥CςυL¦·ΈV―°GλΚOµ/Α.S3

--- a/terraform/proxmox/repos/terraform.tf
+++ b/terraform/proxmox/repos/terraform.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "kubernetes" {
+    secret_suffix    = "proxmox.repos"
+    config_path      = "~/.kube/config"
+    namespace = "terraform"
+  }
+}

--- a/terraform/proxmox/repos/variables.tf
+++ b/terraform/proxmox/repos/variables.tf
@@ -1,0 +1,22 @@
+variable "proxmox_host" {
+  description = "Proxmox host"
+  type        = string
+  default     = "192.168.10.11"
+}
+
+variable "proxmox_token_id" {
+  description = "Proxmox token id"
+  type        = string
+}
+
+variable "proxmox_token_secret" {
+  description = "Proxmox token secret"
+  type        = string
+  sensitive   = true
+}
+
+variable "proxmox_nodes" {
+  description = "Proxmox nodes names"
+  type        = set(string)
+  default     = ["pve-r740xd", "pve-t630"]
+}

--- a/terraform/proxmox/repos/versions.tf
+++ b/terraform/proxmox/repos/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    proxmox = {
+      source  = "bpg/proxmox"
+      version = "0.76.1"
+    }
+  }
+  required_version = ">= 1.5"
+}

--- a/terraform/proxmox/users/.terraform.lock.hcl
+++ b/terraform/proxmox/users/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/bpg/proxmox" {
+  version     = "0.76.1"
+  constraints = "0.76.1"
+  hashes = [
+    "h1:0yFjPKRsNyv14JD50VC6DUudG2vej0NG8uiBA+XfKRI=",
+    "zh:0c0f59d027eb7090e81b92f34ed27c2467c4e03f1e58128372229457f761418a",
+    "zh:4045ca7307abd453373079637c9b15d5972d32fc1e2ab69b635bf3a74dc1032c",
+    "zh:58d0e2d0bd22eb95aa3ee30c7dd6e3cc0986c703ca90cf402fc7634fbb665330",
+    "zh:5aa2058013abbae0c426c110f723a5d3c8d0407ede15616c0151bca8655aaa09",
+    "zh:5e991da91b42bc4912be381f5970a5074538f721dd0fb746947bdf2041821cb1",
+    "zh:62914bb9857802c895fc48144cd8e37c4ef31d01e5c2b8e012ef5f2aad05b8bf",
+    "zh:a55800caab94e20bef1f928e2486d556114f00a1fb67cbd87c26b61025637427",
+    "zh:a6173cd06104d31b6d5327af4ed6e8e10e823870684c2e26dfd5d19e34addc08",
+    "zh:b35bf59f0259744a39fce5e8585f9d28aea017ba30298afa75069563ec13baa8",
+    "zh:bb4fb5f1b282dcd0f71f67edf270d0c35dab844723fcfeef487402950657cedd",
+    "zh:bcc6a4868931272f92b672952ed3b500d0eb68955f4fd3b57a4e2b1de2691176",
+    "zh:ce94d971748676c063d9f7ede2df2911e5bdcd37f6855778a5e61e79890c4204",
+    "zh:ea94593a43dd2dcec04f09cdf7a0376c1843053ae87903056a1a8db5adc1b24c",
+    "zh:f0057c3a50ef93f5ccfb2a1abf672281bc8d9a082ff8ab298f7c0ce5aa077136",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+  ]
+}

--- a/terraform/proxmox/users/README.md
+++ b/terraform/proxmox/users/README.md
@@ -1,0 +1,15 @@
+# Terraform: Proxmox users module
+
+This Terraform module manages Proxmox VE users.
+
+## Import state
+
+```shell
+terraform init
+terraform import proxmox_virtual_environment_group.puqu-team puqu
+terraform import proxmox_virtual_environment_role.puqu-admin puqu-admin
+terraform import proxmox_virtual_environment_user.puqu-user[\"r2r\"] r2r
+terraform import proxmox_virtual_environment_user.puqu-user[\"alex\"] alex
+terraform import proxmox_virtual_environment_user.puqu-user[\"suwara\"] suwara
+terraform import proxmox_virtual_environment_user.puqu-user[\"konrad\"] konrad
+```

--- a/terraform/proxmox/users/auth.tf
+++ b/terraform/proxmox/users/auth.tf
@@ -1,0 +1,5 @@
+provider "proxmox" {
+  endpoint  = "https://${var.proxmox_host}:8006/"
+  insecure  = true
+  api_token = "${var.proxmox_token_id}=${var.proxmox_token_secret}"
+}

--- a/terraform/proxmox/users/main.tf
+++ b/terraform/proxmox/users/main.tf
@@ -1,0 +1,70 @@
+resource "proxmox_virtual_environment_group" "puqu-team" {
+  comment  = "Managed by Terraform"
+  group_id = "puqu"
+}
+
+resource "proxmox_virtual_environment_role" "puqu-admin" {
+  role_id = "puqu-admin"
+
+  privileges = [
+    # Node / System related privileges
+    "SDN.Audit",
+    "Sys.Audit",
+    "Sys.Syslog",
+    "Mapping.Audit",
+    "Mapping.Use",
+    "Pool.Audit",
+    # Virtual machine related privileges
+    "SDN.Use",
+    "VM.Audit",
+    "VM.Allocate",
+    "VM.Backup",
+    "VM.Clone",
+    "VM.Config.CDROM",
+    "VM.Config.CPU",
+    "VM.Config.Cloudinit",
+    "VM.Config.Disk",
+    "VM.Config.HWType",
+    "VM.Config.Memory",
+    "VM.Config.Network",
+    "VM.Config.Options",
+    "VM.Console",
+    "VM.Migrate",
+    "VM.Monitor",
+    "VM.PowerMgmt",
+    "VM.Snapshot.Rollback",
+    "VM.Snapshot",
+    # Storage related privileges
+    "Datastore.Audit",
+    "Datastore.AllocateTemplate",
+    "Datastore.AllocateSpace"
+  ]
+}
+
+resource "proxmox_virtual_environment_user" "puqu-user" {
+  for_each  = var.puqu_users
+  acl {
+    path      = "/vms/100"
+    propagate = true
+    role_id   = "NoAccess"
+  }
+  acl {
+    path     = "/sdn/zones/localnetwork/vmbr0"
+    propagate = true
+    role_id   = "NoAccess"
+  }
+  acl {
+    path      = "/"
+    propagate = true
+    role_id   = proxmox_virtual_environment_role.puqu-admin.role_id
+  }
+
+  enabled  = true
+  comment  = "Managed by Terraform"
+  password = "a-strong-password"
+  email    = each.value.email
+  first_name = each.value.first_name
+  last_name = each.value.last_name
+  user_id  = "${each.value.username}@pve"
+  groups   = [proxmox_virtual_environment_group.puqu-team.group_id]
+}

--- a/terraform/proxmox/users/secrets.auto.tfvars.age
+++ b/terraform/proxmox/users/secrets.auto.tfvars.age
@@ -1,0 +1,6 @@
+age-encryption.org/v1
+-> X25519 5eKNhyFt9a5oxPS+k3nGwzThmEKYhDFqLEnuxOZhdmk
+emeKv4eq0hh0DUkw883eTbI85nyI3wVR1A1hzuQD4kg
+--- NanE1W4BNNnaGPAQHJmkU163Qu3yYMZNjQu9fcyZT6w
+q³/ΟΡGzζφς“«;Ok4Υ/σ7:σE®‡ΜΦwÿ ωl°®	
+ψ¥’ώ®oΘWίf-β’ΤMάA¬ιή6[Gβ‘νεX|¬°ιπ―'ΚµΪΖcbΌΜ¨ΒΜοςΥτwζ)™¥CςυL¦·ΈV―°GλΚOµ/Α.S3

--- a/terraform/proxmox/users/terraform.tf
+++ b/terraform/proxmox/users/terraform.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "kubernetes" {
+    secret_suffix    = "proxmox.users"
+    config_path      = "~/.kube/config"
+    namespace = "terraform"
+  }
+}

--- a/terraform/proxmox/users/variables.tf
+++ b/terraform/proxmox/users/variables.tf
@@ -1,0 +1,52 @@
+variable "proxmox_host" {
+  description = "Proxmox host"
+  type        = string
+  default     = "192.168.10.11"
+}
+
+variable "proxmox_token_id" {
+  description = "Proxmox token id"
+  type        = string
+}
+
+variable "proxmox_token_secret" {
+  description = "Proxmox token secret"
+  type        = string
+  sensitive   = true
+}
+
+variable "puqu_users" {
+  description = "Proxmox puqu users"
+  type = map(object({
+    first_name = string
+    last_name = string
+    email = string
+    username = string
+  }))
+  default = {
+    r2r = {
+      username = "r2r"
+      first_name = "Artur"
+      last_name = "Stachecki"
+      email = "proxmox@r2r.sh"
+    },
+    alex = {
+      username = "alex"
+      first_name = "Aleksander"
+      last_name = "Gondek"
+      email = "proxmox@other-songs.eu"
+    },
+    suwara = {
+      username = "suwara"
+      first_name = "Michal"
+      last_name = "Suwara"
+      email = "suwara.michal+proxmox@asml.com"
+    },
+    konrad = {
+      username = "konrad"
+      first_name = "Konrad"
+      last_name = "Kolodziejczyk"
+      email = "konrad.kk+proxmox@gmail.com"
+    }
+  }
+}

--- a/terraform/proxmox/users/versions.tf
+++ b/terraform/proxmox/users/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    proxmox = {
+      source  = "bpg/proxmox"
+      version = "0.76.1"
+    }
+  }
+  required_version = ">= 1.5"
+}


### PR DESCRIPTION
This change implements the following Proxmox terraform modules:
* users - manages Proxmox VE users.
* repos - manages Proxmox host APT repositories across all Proxmox nodes in a cluster.
* network - manages NICs and Linux bridges across all Proxmox nodes in a cluster
* acme - provisions and manages both a Let's Encrypt ACME account and the OVH DSN01 ACME plugin