### PR TITLE
feat: reimplements actions-runner image from ground up with Bazel

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This is a mono repository for my home infrastructure and Kubernetes cluster. I t
   * Storage:
     * [Dell PowerEdge RAID Controller H330](https://i.dell.com/sites/csdocuments/Shared-Content_data-Sheets_Documents/en/Dell-PowerEdge-RAID-Controller-H330.pdf)
     * 4x Samsung 870 EVO SSD
-    * 4x Samsung PM963 960GB SSD NVMe U.2 Gen 3
+    * 6x Samsung PM963 960GB SSD NVMe U.2 Gen 3
 * [Dell PowerEdge T630 GPU Rack](https://i.dell.com/sites/doccontent/shared-content/data-sheets/pl/Documents/Dell-PowerEdge-T630-Spec-Sheet.pdf)
 
   <details>
@@ -44,7 +44,12 @@ This is a mono repository for my home infrastructure and Kubernetes cluster. I t
     * [Dell PowerEdge Raid Controller H330](https://i.dell.com/sites/doccontent/shared-content/data-sheets/en/Documents/Dell-PowerEdge-RAID-Controller-H330.pdf) (in HBA mode)
     * 4x Seagate Exos X16 12TB 7.2k SATA 6Gbps ([ST12000NM001G-2M](https://www.seagate.com/www-content/product-content/enterprise-hdd-fam/exos-x-16/en-us/docs/100845789f.pdf))
     * 2x Goodram CX400 1TB 2,5" Sata3 (SSDPR-CX400-01T-)
-    * 2x Samsung PM963 960GB SSD NVMe U.2 Gen 3
+    * 4x Samsung PM963 960GB SSD NVMe U.2 Gen 3
+  * PCI:
+    * [4 M.2 NVMe SSD PCIe x16 Adapter with PLX 8747 PCI Express 3.0 x16](https://www.aliexpress.com/item/1005006013613064.html)
+    * 10GB NIC Intel X550T2
+    * Dell T630 4* 2.5" PCIE U.2 nvme Backplane Expansion Hdd Cage kit WYNC0
+    * SSD NVMe PCIe EXTENDER EXPANSION CARD GY1TD
 * Ollama/gaming PC
   * Motherboard: Gigabyte X570 AORUS MASTER
     * CPU: AMD Ryzen 9 3900X (12 cores, 3.8 GHz)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,6 +38,15 @@ http_file(
     url = "https://github.com/bazelbuild/bazelisk/releases/download/v1.26.0/bazelisk-linux-amd64",
 )
 
+# GitHub Actions runner
+
+http_archive(
+    name = "runner",
+    build_file = "@home-ops//bazel/third_party:runner.bazel",
+    sha256 = "e8e24a3477da17040b4d6fa6d34c6ecb9a2879e800aa532518ec21e49e21d7b4",
+    url = "https://github.com/actions/runner/releases/download/v2.324.0/actions-runner-linux-x64-2.324.0.tar.gz",
+)
+
 # Skylib
 
 http_archive(
@@ -140,15 +149,6 @@ oci_pull(
     name = "distroless_base",
     digest = "sha256:27769871031f67460f1545a52dfacead6d18a9f197db77110cfc649ca2a91f44",
     image = "gcr.io/distroless/base",
-    platforms = [
-        "linux/amd64",
-    ],
-)
-
-oci_pull(
-    name = "actions_runner",
-    digest = "sha256:831a2607a2618e4b79d9323b4c72330f3861768a061c2b92a845e9d214d80e5b",
-    image = "ghcr.io/actions/actions-runner",
     platforms = [
         "linux/amd64",
     ],

--- a/bazel/third_party/runner.bazel
+++ b/bazel/third_party/runner.bazel
@@ -1,0 +1,14 @@
+filegroup(
+  name = "actions-runner",
+  srcs = glob([
+    "externals/**",
+    "bin/**",
+    "config.sh",
+    "safe_sleep.sh",
+    "run-helper.cmd.template",
+    "run.sh",
+    "run-helper.sh.template",
+    "env.sh",
+  ]),
+  visibility = ["//visibility:public"],
+)

--- a/images/actions-runner/BUILD.bazel
+++ b/images/actions-runner/BUILD.bazel
@@ -1,13 +1,140 @@
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
 load("@rules_distroless//apt:defs.bzl", "dpkg_status")
+load("@rules_distroless//distroless:defs.bzl", "cacerts", "locale", "group", "home", "passwd")
+load("@aspect_bazel_lib//lib:tar.bzl", "tar")
+load("//images/common:variables.bzl", "MTIME", "ROOT")
 
 
 PACKAGES = [
-    "@ubuntu_jammy//curl",
+    "@ubuntu_jammy//libc-bin",
+    "@ubuntu_jammy//libicu70",
+    "@ubuntu_jammy//libssl3",
+    "@ubuntu_jammy//libstdc++6",
+    "@ubuntu_jammy//tzdata",
+    "@ubuntu_jammy//zlib1g",
+    "@ubuntu_jammy//gcc",
     "@ubuntu_jammy//git",
+    "@ubuntu_jammy//gawk",
+    "@ubuntu_jammy//curl",
     "@ubuntu_jammy//xz-utils",
+    "@ubuntu_jammy//sudo",
+    "@ubuntu_jammy//lsb-release",
+    "@ubuntu_jammy//gpg-agent",
+    "@ubuntu_jammy//software-properties-common",
+    "@ubuntu_jammy//unzip",
+    "@ubuntu_jammy//coreutils",
+    "@ubuntu_jammy//bash",
+    "@ubuntu_jammy//jq",
+    "@ubuntu_jammy//grep",
 ]
+RUNNER_UID = 1000
+RUNNER_GID = 1000
+
+
+tar(
+    name = "symlinks",
+    srcs = [],
+    args = [
+        "--format",
+        "gnutar",
+    ],
+    compress = "gzip",
+    mtree = [
+        "./bin/ uid=0 gid=0 mode=0755 time=0.0 type=dir",
+        "./bin/sh uid=0 gid=0 mode=0755 time=0.0 type=link link=/bin/bash",
+        "./usr/bin uid=0 gid=0 mode=0755 time=0.0 type=dir",
+        "./usr/bin/awk uid=0 gid=0 mode=0755 time=0.0 type=link link=/usr/bin/gawk",
+    ],
+)
+
+group(
+    name = "runner-group",
+    entries = [
+        {
+            "name": "root",  # root_group
+            "gid": ROOT,
+            "password": "x",
+        },
+        {
+            "name": "tty",  # tty_group
+            "gid": 5,
+            "password": "x",
+        },
+        {
+            "name": "staff",  # staff_group
+            "gid": 50,
+            "password": "x",
+        },
+        {
+            "name": "runner",
+            "gid": RUNNER_GID,
+            "password": "x",
+        },
+    ],
+    time = MTIME,
+)
+
+passwd(
+    name = "runner-passwd",
+    entries = [
+        {
+            "gecos": ["root"],
+            "gid": ROOT,
+            "shell": "/sbin/nologin",
+            "home": "/root",
+            "uid": ROOT,
+            "password": "x",
+            "username": "root",
+        },
+        {
+            "gecos": ["runner"],
+            "gid": RUNNER_GID,
+            "home": "/home/runner",
+            "shell": "/bin/bash",
+            "uid": RUNNER_UID,
+            "password": "x",
+            "username": "runner",
+        },
+    ],
+)
+
+home(
+    name = "runner-home",
+    dirs = [
+                {
+            "home": "/root",
+            "uid": ROOT,
+            "gid": ROOT,
+            "mode": 700,
+        },
+        {
+            "home": "/home",
+            "uid": ROOT,
+            "gid": ROOT,
+            "mode": 755,
+        },
+        {
+            "home": "/home/runner",
+            "uid": RUNNER_UID,
+            "gid": RUNNER_GID,
+            "mode": 700,
+        },
+    ],
+)
+
+cacerts(
+    name = "cacerts",
+    package = "@ubuntu_jammy//ca-certificates/amd64:data",
+    time = MTIME,
+)
+
+locale(
+    name = "locale",
+    charset = "C.utf8",
+    package = "@ubuntu_jammy//libc-bin/amd64:data",
+    time = MTIME,
+)
 
 # Creates /var/lib/dpkg/status with installed package information.
 dpkg_status(
@@ -21,35 +148,65 @@ dpkg_status(
 )
 
 sh_binary(
-    name = "bazelisk",
+    name = "bazel",
     srcs = ["@bazelisk//file:file"],
 )
 
 pkg_tar(
     name = "bazelisk_tar",
-    srcs = [":bazelisk"],
+    srcs = [":bazel"],
     strip_prefix = ".",
     package_dir = "/usr/local/bin",
 )
 
+pkg_tar(
+    name = "action_runner_tar",
+    srcs = ["@runner//:actions-runner"],
+    strip_prefix = ".",
+    remap_paths = {
+      "external/runner": "",
+    },
+    package_dir = "/home/runner",
+    owner = "{}.{}".format(RUNNER_UID, RUNNER_GID),
+    mode = "0755"
+)
+
 oci_image(
     name = "image",
-    base = "@actions_runner",
+    # base = "@distroless_base",
+    env = {
+        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "SSL_CERT_FILE": "/etc/ssl/certs/ca-certificates.crt",
+        "DEBIAN_FRONTEND": "noninteractive",
+    },
+    os = "linux",
+    architecture = "amd64",
     tars = [
-        ":dpkg_status",
+        "//images/common:rootfs",
+        ":runner-passwd",
+        ":runner-home",
+        ":runner-group",
+        "//images/common:tmp",
+        ":cacerts",
+        ":locale",
         ":bazelisk_tar",
+        ":action_runner_tar",
+        ":dpkg_status",
+        ":symlinks",
     ] + select({
         "@platforms//cpu:x86_64": [
             "%s/amd64" % package
             for package in PACKAGES
         ],
     }),
-    cmd = ["/usr/bin/bash"],
+    cmd = ["/bin/bash"],
+    user = "%d" % RUNNER_UID,
+    workdir = "/home/runner",
 )
 
 oci_push(
     name = "push_image",
     image = ":image",
     remote_tags = ["latest"],
-    repository = "ghcr.io/rszamszur/actions-runner",
+    repository = "harbor.puqu.io/rszamszur/actions-runner",
 )

--- a/images/actions-runner/apt.lock.json
+++ b/images/actions-runner/apt.lock.json
@@ -4,6 +4,645 @@
 			"arch": "amd64",
 			"dependencies": [
 				{
+					"key": "libc6_2.35-0ubuntu3.8_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3.8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libgcc-s1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libgcc-s1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "gcc-12-base_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "gcc-12-base",
+					"version": "12.3.0-1ubuntu1~22.04"
+				}
+			],
+			"key": "libc-bin_2.35-0ubuntu3.8_amd64",
+			"name": "libc-bin",
+			"sha256": "d29910f1343d073edcc14dda5d80ba4aa494395ecdbe56a868c168f26ad4e520",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/glibc/libc-bin_2.35-0ubuntu3.8_amd64.deb",
+			"version": "2.35-0ubuntu3.8"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libc6_2.35-0ubuntu3.8_amd64",
+			"name": "libc6",
+			"sha256": "76d582e6b5a7057acd8b239edf102329a5a966303d7d1b7a024b447e057b342e",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/glibc/libc6_2.35-0ubuntu3.8_amd64.deb",
+			"version": "2.35-0ubuntu3.8"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcrypt1_1-4.4.27-1_amd64",
+			"name": "libcrypt1",
+			"sha256": "3fa566e9f861a08736cbc5a97562d9d6e4f0c00450fbeafcb6d7583423b04a98",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/libx/libxcrypt/libcrypt1_4.4.27-1_amd64.deb",
+			"version": "1:4.4.27-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgcc-s1_12.3.0-1ubuntu1_22.04_amd64",
+			"name": "libgcc-s1",
+			"sha256": "8ca7b573446d22ef46a97b4ec537c38acc8653f76391127253040acc7b74af5f",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gcc-12/libgcc-s1_12.3.0-1ubuntu1~22.04_amd64.deb",
+			"version": "12.3.0-1ubuntu1~22.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "gcc-12-base_12.3.0-1ubuntu1_22.04_amd64",
+			"name": "gcc-12-base",
+			"sha256": "80a1f5df097af3978f7df2808006ca77197865e5eb7a923712aee6876e7a14cb",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gcc-12/gcc-12-base_12.3.0-1ubuntu1~22.04_amd64.deb",
+			"version": "12.3.0-1ubuntu1~22.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "openssl_3.0.2-0ubuntu1.17_amd64",
+					"name": "openssl",
+					"version": "3.0.2-0ubuntu1.17"
+				},
+				{
+					"key": "libssl3_3.0.2-0ubuntu1.17_amd64",
+					"name": "libssl3",
+					"version": "3.0.2-0ubuntu1.17"
+				},
+				{
+					"key": "libc6_2.35-0ubuntu3.8_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3.8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libgcc-s1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libgcc-s1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "gcc-12-base_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "gcc-12-base",
+					"version": "12.3.0-1ubuntu1~22.04"
+				}
+			],
+			"key": "ca-certificates_20230311ubuntu0.22.04.1_amd64",
+			"name": "ca-certificates",
+			"sha256": "8ddd3b5d72fa144e53974d6a5782d25a0a9e1eec006118ecf2b76d53a7530f6a",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/c/ca-certificates/ca-certificates_20230311ubuntu0.22.04.1_all.deb",
+			"version": "20230311ubuntu0.22.04.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "openssl_3.0.2-0ubuntu1.17_amd64",
+			"name": "openssl",
+			"sha256": "9cd6f5215bc7d106b241caba1ba8d214475c076c8a86333f571c48a8201e909d",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/o/openssl/openssl_3.0.2-0ubuntu1.17_amd64.deb",
+			"version": "3.0.2-0ubuntu1.17"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libc6_2.35-0ubuntu3.8_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3.8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libgcc-s1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libgcc-s1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "gcc-12-base_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "gcc-12-base",
+					"version": "12.3.0-1ubuntu1~22.04"
+				}
+			],
+			"key": "libssl3_3.0.2-0ubuntu1.17_amd64",
+			"name": "libssl3",
+			"sha256": "b550e92a8f03146de1fedf3e9ad6fdb515c85158ef29d3cf9091e7bdfc849a50",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/o/openssl/libssl3_3.0.2-0ubuntu1.17_amd64.deb",
+			"version": "3.0.2-0ubuntu1.17"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libstdc-p--p-6_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libstdc++6",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "libgcc-s1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libgcc-s1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "libc6_2.35-0ubuntu3.8_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3.8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "gcc-12-base_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "gcc-12-base",
+					"version": "12.3.0-1ubuntu1~22.04"
+				}
+			],
+			"key": "libicu70_70.1-2_amd64",
+			"name": "libicu70",
+			"sha256": "58a154f6307289813da2276f900498ef536ae7c0522d2cf31a3c3c5cf62dfd9a",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/i/icu/libicu70_70.1-2_amd64.deb",
+			"version": "70.1-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libgcc-s1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libgcc-s1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "libc6_2.35-0ubuntu3.8_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3.8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "gcc-12-base_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "gcc-12-base",
+					"version": "12.3.0-1ubuntu1~22.04"
+				}
+			],
+			"key": "libstdc-p--p-6_12.3.0-1ubuntu1_22.04_amd64",
+			"name": "libstdc++6",
+			"sha256": "83873058e692936a09649ede2f8e70b87dde1f3f5488db53da8081b81c79a5d9",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gcc-12/libstdc++6_12.3.0-1ubuntu1~22.04_amd64.deb",
+			"version": "12.3.0-1ubuntu1~22.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "tzdata_2024a-0ubuntu0.22.04.1_amd64",
+			"name": "tzdata",
+			"sha256": "e18ea97de33b630b1e1899ab41d32c5b915f7770af188b94f6ce5241c512c4a3",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/t/tzdata/tzdata_2024a-0ubuntu0.22.04.1_all.deb",
+			"version": "2024a-0ubuntu0.22.04.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libc6_2.35-0ubuntu3.8_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3.8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libgcc-s1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libgcc-s1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "gcc-12-base_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "gcc-12-base",
+					"version": "12.3.0-1ubuntu1~22.04"
+				}
+			],
+			"key": "zlib1g_1-1.2.11.dfsg-2ubuntu9.2_amd64",
+			"name": "zlib1g",
+			"sha256": "9dc17e51a1be2d9ed63b7b84ef0e4e29c5abe6f1bc62cb03e7181483cce8a2f2",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/z/zlib/zlib1g_1.2.11.dfsg-2ubuntu9.2_amd64.deb",
+			"version": "1:1.2.11.dfsg-2ubuntu9.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "gcc-11_11.4.0-1ubuntu1_22.04_amd64",
+					"name": "gcc-11",
+					"version": "11.4.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2ubuntu9.2_amd64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2ubuntu9.2"
+				},
+				{
+					"key": "libc6_2.35-0ubuntu3.8_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3.8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libgcc-s1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libgcc-s1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "gcc-12-base_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "gcc-12-base",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "libzstd1_1.4.8-p-dfsg-3build1_amd64",
+					"name": "libzstd1",
+					"version": "1.4.8+dfsg-3build1"
+				},
+				{
+					"key": "libstdc-p--p-6_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libstdc++6",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "libmpfr6_4.1.0-3build3_amd64",
+					"name": "libmpfr6",
+					"version": "4.1.0-3build3"
+				},
+				{
+					"key": "libgmp10_2-6.2.1-p-dfsg-3ubuntu1_amd64",
+					"name": "libgmp10",
+					"version": "2:6.2.1+dfsg-3ubuntu1"
+				},
+				{
+					"key": "libmpc3_1.2.1-2build1_amd64",
+					"name": "libmpc3",
+					"version": "1.2.1-2build1"
+				},
+				{
+					"key": "libisl23_0.24-2build1_amd64",
+					"name": "libisl23",
+					"version": "0.24-2build1"
+				},
+				{
+					"key": "libgcc-11-dev_11.4.0-1ubuntu1_22.04_amd64",
+					"name": "libgcc-11-dev",
+					"version": "11.4.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "libquadmath0_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libquadmath0",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "libubsan1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libubsan1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "libtsan0_11.4.0-1ubuntu1_22.04_amd64",
+					"name": "libtsan0",
+					"version": "11.4.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "gcc-11-base_11.4.0-1ubuntu1_22.04_amd64",
+					"name": "gcc-11-base",
+					"version": "11.4.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "liblsan0_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "liblsan0",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "libasan6_11.4.0-1ubuntu1_22.04_amd64",
+					"name": "libasan6",
+					"version": "11.4.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "libatomic1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libatomic1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "libitm1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libitm1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "libgomp1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libgomp1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "binutils_2.38-4ubuntu2.6_amd64",
+					"name": "binutils",
+					"version": "2.38-4ubuntu2.6"
+				},
+				{
+					"key": "binutils-x86-64-linux-gnu_2.38-4ubuntu2.6_amd64",
+					"name": "binutils-x86-64-linux-gnu",
+					"version": "2.38-4ubuntu2.6"
+				},
+				{
+					"key": "libctf0_2.38-4ubuntu2.6_amd64",
+					"name": "libctf0",
+					"version": "2.38-4ubuntu2.6"
+				},
+				{
+					"key": "libbinutils_2.38-4ubuntu2.6_amd64",
+					"name": "libbinutils",
+					"version": "2.38-4ubuntu2.6"
+				},
+				{
+					"key": "binutils-common_2.38-4ubuntu2.6_amd64",
+					"name": "binutils-common",
+					"version": "2.38-4ubuntu2.6"
+				},
+				{
+					"key": "libctf-nobfd0_2.38-4ubuntu2.6_amd64",
+					"name": "libctf-nobfd0",
+					"version": "2.38-4ubuntu2.6"
+				},
+				{
+					"key": "libcc1-0_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libcc1-0",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "cpp-11_11.4.0-1ubuntu1_22.04_amd64",
+					"name": "cpp-11",
+					"version": "11.4.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "cpp_4-11.2.0-1ubuntu1_amd64",
+					"name": "cpp",
+					"version": "4:11.2.0-1ubuntu1"
+				}
+			],
+			"key": "gcc_4-11.2.0-1ubuntu1_amd64",
+			"name": "gcc",
+			"sha256": "be895c1a9611905254f818c41092f147f5f2a566f87f1817b5c36d977020bea7",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gcc-defaults/gcc_11.2.0-1ubuntu1_amd64.deb",
+			"version": "4:11.2.0-1ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "gcc-11_11.4.0-1ubuntu1_22.04_amd64",
+			"name": "gcc-11",
+			"sha256": "ac218d4917da42d55e269a9650264bf3b7f7e211d3d7d665c63eb74db8222e12",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gcc-11/gcc-11_11.4.0-1ubuntu1~22.04_amd64.deb",
+			"version": "11.4.0-1ubuntu1~22.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libzstd1_1.4.8-p-dfsg-3build1_amd64",
+			"name": "libzstd1",
+			"sha256": "ae7db00ce8b093e50c994518b90203544e063b4bc574836a048bb142b950b2c9",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-3build1_amd64.deb",
+			"version": "1.4.8+dfsg-3build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libmpfr6_4.1.0-3build3_amd64",
+			"name": "libmpfr6",
+			"sha256": "ffdc36247e5fc96ba3fca5a9448856c9327e93631ce5646acd9fffd286d10de3",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/m/mpfr4/libmpfr6_4.1.0-3build3_amd64.deb",
+			"version": "4.1.0-3build3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgmp10_2-6.2.1-p-dfsg-3ubuntu1_amd64",
+			"name": "libgmp10",
+			"sha256": "d199a77e11701d4d620dd4f62e05740e3072dce893856ea3bbaa6ae9fa19fef1",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-3ubuntu1_amd64.deb",
+			"version": "2:6.2.1+dfsg-3ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libmpc3_1.2.1-2build1_amd64",
+			"name": "libmpc3",
+			"sha256": "6cd43b60ac14890737a3402a35350d6696bc1521de8731cdecc9e7ef10041446",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/m/mpclib3/libmpc3_1.2.1-2build1_amd64.deb",
+			"version": "1.2.1-2build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libisl23_0.24-2build1_amd64",
+			"name": "libisl23",
+			"sha256": "4cb0faab32c896165cf4ebe3c3ebce3176bf869453636d7fe8be89dccc2ae5af",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/i/isl/libisl23_0.24-2build1_amd64.deb",
+			"version": "0.24-2build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgcc-11-dev_11.4.0-1ubuntu1_22.04_amd64",
+			"name": "libgcc-11-dev",
+			"sha256": "06faa64479f1987e4f870ff9c1ccfdf3c0c441bd3886136d6e24c11316c9f3d6",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gcc-11/libgcc-11-dev_11.4.0-1ubuntu1~22.04_amd64.deb",
+			"version": "11.4.0-1ubuntu1~22.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libquadmath0_12.3.0-1ubuntu1_22.04_amd64",
+			"name": "libquadmath0",
+			"sha256": "6bf564c2bb191aefcf96758502a7ac24b2af4d644c87b3678e4b1107c5494b13",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gcc-12/libquadmath0_12.3.0-1ubuntu1~22.04_amd64.deb",
+			"version": "12.3.0-1ubuntu1~22.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libubsan1_12.3.0-1ubuntu1_22.04_amd64",
+			"name": "libubsan1",
+			"sha256": "becb1726d3b8a45cfd336e502fc29d7c43e024689857c670ecf75a5362732c63",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gcc-12/libubsan1_12.3.0-1ubuntu1~22.04_amd64.deb",
+			"version": "12.3.0-1ubuntu1~22.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libtsan0_11.4.0-1ubuntu1_22.04_amd64",
+			"name": "libtsan0",
+			"sha256": "7b14e81317fce5e62d6cc2454d975d3ec4eac90710a1a536d63c9ee84a50b6f2",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gcc-11/libtsan0_11.4.0-1ubuntu1~22.04_amd64.deb",
+			"version": "11.4.0-1ubuntu1~22.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "gcc-11-base_11.4.0-1ubuntu1_22.04_amd64",
+			"name": "gcc-11-base",
+			"sha256": "5448bba72109dbf2df6ee30463b5f06c074138006cd1d5730fb5189b93e6d563",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gcc-11/gcc-11-base_11.4.0-1ubuntu1~22.04_amd64.deb",
+			"version": "11.4.0-1ubuntu1~22.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "liblsan0_12.3.0-1ubuntu1_22.04_amd64",
+			"name": "liblsan0",
+			"sha256": "606e212c3cbc8fb622313fdb32f78a024b4b5b9fe54b1cc5a8f731297023b899",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gcc-12/liblsan0_12.3.0-1ubuntu1~22.04_amd64.deb",
+			"version": "12.3.0-1ubuntu1~22.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libasan6_11.4.0-1ubuntu1_22.04_amd64",
+			"name": "libasan6",
+			"sha256": "0580e3209722dd0e6d9e57c4149a0f8f6073f975cf8b5ede26ac54289c2fc99a",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gcc-11/libasan6_11.4.0-1ubuntu1~22.04_amd64.deb",
+			"version": "11.4.0-1ubuntu1~22.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libatomic1_12.3.0-1ubuntu1_22.04_amd64",
+			"name": "libatomic1",
+			"sha256": "56ec991983c7c89a2c15bd5134534531d722ec5b51a60679f7ceaa1a09b37a09",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gcc-12/libatomic1_12.3.0-1ubuntu1~22.04_amd64.deb",
+			"version": "12.3.0-1ubuntu1~22.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libitm1_12.3.0-1ubuntu1_22.04_amd64",
+			"name": "libitm1",
+			"sha256": "ac3c96ed50a42b4f57c410576bdf816710684e3e32e34f704a7295014565b724",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gcc-12/libitm1_12.3.0-1ubuntu1~22.04_amd64.deb",
+			"version": "12.3.0-1ubuntu1~22.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgomp1_12.3.0-1ubuntu1_22.04_amd64",
+			"name": "libgomp1",
+			"sha256": "072a7ee2dc00bc92a816e11ae62ad5a497c86fc1f0473c0a095f29e13003da72",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gcc-12/libgomp1_12.3.0-1ubuntu1~22.04_amd64.deb",
+			"version": "12.3.0-1ubuntu1~22.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "binutils_2.38-4ubuntu2.6_amd64",
+			"name": "binutils",
+			"sha256": "1fc8beaf8ae192b59fcd8733d0dedb1e2ec60b1c0832c23b3e07dd0c77610974",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/b/binutils/binutils_2.38-4ubuntu2.6_amd64.deb",
+			"version": "2.38-4ubuntu2.6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "binutils-x86-64-linux-gnu_2.38-4ubuntu2.6_amd64",
+			"name": "binutils-x86-64-linux-gnu",
+			"sha256": "be2f07fecec147d30ff021167eb8ace6e7773e6f8c6d5458637b16975bfad97f",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/b/binutils/binutils-x86-64-linux-gnu_2.38-4ubuntu2.6_amd64.deb",
+			"version": "2.38-4ubuntu2.6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libctf0_2.38-4ubuntu2.6_amd64",
+			"name": "libctf0",
+			"sha256": "5b0801e05ead79575abc54a42b3bc8a5ea1850240a74395c2d0deb9dceb35d8f",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/b/binutils/libctf0_2.38-4ubuntu2.6_amd64.deb",
+			"version": "2.38-4ubuntu2.6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libbinutils_2.38-4ubuntu2.6_amd64",
+			"name": "libbinutils",
+			"sha256": "cfe3e895d52eff3d58383a2eeb5ecdb5d6e01af6da0ac1efcc24a1d291357d96",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/b/binutils/libbinutils_2.38-4ubuntu2.6_amd64.deb",
+			"version": "2.38-4ubuntu2.6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "binutils-common_2.38-4ubuntu2.6_amd64",
+			"name": "binutils-common",
+			"sha256": "9cbe03a26020ef6ae7c881a6d28faae73f588b0a913aa1d31a21ba4dcfcc89d1",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/b/binutils/binutils-common_2.38-4ubuntu2.6_amd64.deb",
+			"version": "2.38-4ubuntu2.6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libctf-nobfd0_2.38-4ubuntu2.6_amd64",
+			"name": "libctf-nobfd0",
+			"sha256": "b3d1cea1d9f27ce9eb8ea0ae0de397d403ae198e9c941eb7f55aa1584425a344",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/b/binutils/libctf-nobfd0_2.38-4ubuntu2.6_amd64.deb",
+			"version": "2.38-4ubuntu2.6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcc1-0_12.3.0-1ubuntu1_22.04_amd64",
+			"name": "libcc1-0",
+			"sha256": "7ae1a7e858b32481bba64d6ea17deacd7f3969f54c040f477562f0b5da3df6de",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gcc-12/libcc1-0_12.3.0-1ubuntu1~22.04_amd64.deb",
+			"version": "12.3.0-1ubuntu1~22.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "cpp-11_11.4.0-1ubuntu1_22.04_amd64",
+			"name": "cpp-11",
+			"sha256": "5d837dc204d60024d9439d19b186c6c75f6598c6ef2c95630536041e65d41a1f",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gcc-11/cpp-11_11.4.0-1ubuntu1~22.04_amd64.deb",
+			"version": "11.4.0-1ubuntu1~22.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "cpp_4-11.2.0-1ubuntu1_amd64",
+			"name": "cpp",
+			"sha256": "44f881cf66bfaac163a6c45b4bfb5e79a40780b96af78bec6e9c58f973b8d7bd",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gcc-defaults/cpp_11.2.0-1ubuntu1_amd64.deb",
+			"version": "4:11.2.0-1ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
 					"key": "git-man_1-2.34.1-1ubuntu1.11_amd64",
 					"name": "git-man",
 					"version": "1:2.34.1-1ubuntu1.11"
@@ -343,65 +982,11 @@
 		{
 			"arch": "amd64",
 			"dependencies": [],
-			"key": "libc6_2.35-0ubuntu3.8_amd64",
-			"name": "libc6",
-			"sha256": "76d582e6b5a7057acd8b239edf102329a5a966303d7d1b7a024b447e057b342e",
-			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/glibc/libc6_2.35-0ubuntu3.8_amd64.deb",
-			"version": "2.35-0ubuntu3.8"
-		},
-		{
-			"arch": "amd64",
-			"dependencies": [],
-			"key": "libcrypt1_1-4.4.27-1_amd64",
-			"name": "libcrypt1",
-			"sha256": "3fa566e9f861a08736cbc5a97562d9d6e4f0c00450fbeafcb6d7583423b04a98",
-			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/libx/libxcrypt/libcrypt1_4.4.27-1_amd64.deb",
-			"version": "1:4.4.27-1"
-		},
-		{
-			"arch": "amd64",
-			"dependencies": [],
-			"key": "libgcc-s1_12.3.0-1ubuntu1_22.04_amd64",
-			"name": "libgcc-s1",
-			"sha256": "8ca7b573446d22ef46a97b4ec537c38acc8653f76391127253040acc7b74af5f",
-			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gcc-12/libgcc-s1_12.3.0-1ubuntu1~22.04_amd64.deb",
-			"version": "12.3.0-1ubuntu1~22.04"
-		},
-		{
-			"arch": "amd64",
-			"dependencies": [],
-			"key": "gcc-12-base_12.3.0-1ubuntu1_22.04_amd64",
-			"name": "gcc-12-base",
-			"sha256": "80a1f5df097af3978f7df2808006ca77197865e5eb7a923712aee6876e7a14cb",
-			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gcc-12/gcc-12-base_12.3.0-1ubuntu1~22.04_amd64.deb",
-			"version": "12.3.0-1ubuntu1~22.04"
-		},
-		{
-			"arch": "amd64",
-			"dependencies": [],
 			"key": "libacl1_2.3.1-1_amd64",
 			"name": "libacl1",
 			"sha256": "4db2c64ec74f673ed022e92cce7b83d0cbe0b779e02ca60a56ba59ae07754e05",
 			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/a/acl/libacl1_2.3.1-1_amd64.deb",
 			"version": "2.3.1-1"
-		},
-		{
-			"arch": "amd64",
-			"dependencies": [],
-			"key": "zlib1g_1-1.2.11.dfsg-2ubuntu9.2_amd64",
-			"name": "zlib1g",
-			"sha256": "9dc17e51a1be2d9ed63b7b84ef0e4e29c5abe6f1bc62cb03e7181483cce8a2f2",
-			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/z/zlib/zlib1g_1.2.11.dfsg-2ubuntu9.2_amd64.deb",
-			"version": "1:1.2.11.dfsg-2ubuntu9.2"
-		},
-		{
-			"arch": "amd64",
-			"dependencies": [],
-			"key": "libzstd1_1.4.8-p-dfsg-3build1_amd64",
-			"name": "libzstd1",
-			"sha256": "ae7db00ce8b093e50c994518b90203544e063b4bc574836a048bb142b950b2c9",
-			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-3build1_amd64.deb",
-			"version": "1.4.8+dfsg-3build1"
 		},
 		{
 			"arch": "amd64",
@@ -474,15 +1059,6 @@
 			"sha256": "b62e9cd6feac51c981a8a44c4af24eafde6c1ce7717548d5b9402a034368185f",
 			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/libs/libssh/libssh-4_0.9.6-2ubuntu0.22.04.3_amd64.deb",
 			"version": "0.9.6-2ubuntu0.22.04.3"
-		},
-		{
-			"arch": "amd64",
-			"dependencies": [],
-			"key": "libssl3_3.0.2-0ubuntu1.17_amd64",
-			"name": "libssl3",
-			"sha256": "b550e92a8f03146de1fedf3e9ad6fdb515c85158ef29d3cf9091e7bdfc849a50",
-			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/o/openssl/libssl3_3.0.2-0ubuntu1.17_amd64.deb",
-			"version": "3.0.2-0ubuntu1.17"
 		},
 		{
 			"arch": "amd64",
@@ -564,15 +1140,6 @@
 			"sha256": "2402ac51ebc760799b01f3fd4933126c5eb446e5b043832601fb589f5e50c363",
 			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/n/nettle/libhogweed6_3.7.3-1build2_amd64.deb",
 			"version": "3.7.3-1build2"
-		},
-		{
-			"arch": "amd64",
-			"dependencies": [],
-			"key": "libgmp10_2-6.2.1-p-dfsg-3ubuntu1_amd64",
-			"name": "libgmp10",
-			"sha256": "d199a77e11701d4d620dd4f62e05740e3072dce893856ea3bbaa6ae9fa19fef1",
-			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-3ubuntu1_amd64.deb",
-			"version": "2:6.2.1+dfsg-3ubuntu1"
 		},
 		{
 			"arch": "amd64",
@@ -865,6 +1432,102 @@
 			"arch": "amd64",
 			"dependencies": [
 				{
+					"key": "libsigsegv2_2.13-1ubuntu3_amd64",
+					"name": "libsigsegv2",
+					"version": "2.13-1ubuntu3"
+				},
+				{
+					"key": "libc6_2.35-0ubuntu3.8_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3.8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libgcc-s1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libgcc-s1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "gcc-12-base_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "gcc-12-base",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "libreadline8_8.1.2-1_amd64",
+					"name": "libreadline8",
+					"version": "8.1.2-1"
+				},
+				{
+					"key": "libtinfo6_6.3-2ubuntu0.1_amd64",
+					"name": "libtinfo6",
+					"version": "6.3-2ubuntu0.1"
+				},
+				{
+					"key": "readline-common_8.1.2-1_amd64",
+					"name": "readline-common",
+					"version": "8.1.2-1"
+				},
+				{
+					"key": "libmpfr6_4.1.0-3build3_amd64",
+					"name": "libmpfr6",
+					"version": "4.1.0-3build3"
+				},
+				{
+					"key": "libgmp10_2-6.2.1-p-dfsg-3ubuntu1_amd64",
+					"name": "libgmp10",
+					"version": "2:6.2.1+dfsg-3ubuntu1"
+				}
+			],
+			"key": "gawk_1-5.1.0-1ubuntu0.1_amd64",
+			"name": "gawk",
+			"sha256": "1d06b2f83ebccf73b692dfbb02e7f9414dc49f57e97f7ca104934ce37fae900b",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gawk/gawk_5.1.0-1ubuntu0.1_amd64.deb",
+			"version": "1:5.1.0-1ubuntu0.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsigsegv2_2.13-1ubuntu3_amd64",
+			"name": "libsigsegv2",
+			"sha256": "894fcb0804df54dca59edbd0860d6f3eeac25d1555aebd3fa99d80665969f891",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/libs/libsigsegv/libsigsegv2_2.13-1ubuntu3_amd64.deb",
+			"version": "2.13-1ubuntu3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libreadline8_8.1.2-1_amd64",
+			"name": "libreadline8",
+			"sha256": "51fd16f608efa710c987e4b071ffba0bec63a9ac8e55eddd5770f5e5252edc09",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/r/readline/libreadline8_8.1.2-1_amd64.deb",
+			"version": "8.1.2-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libtinfo6_6.3-2ubuntu0.1_amd64",
+			"name": "libtinfo6",
+			"sha256": "1ec03fe34a7dfd8640a0564a3cad385a10b4f68ebf2190a4c08ccadb395133d3",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/n/ncurses/libtinfo6_6.3-2ubuntu0.1_amd64.deb",
+			"version": "6.3-2ubuntu0.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "readline-common_8.1.2-1_amd64",
+			"name": "readline-common",
+			"sha256": "a78d02935f6107a12d3d349c25ce4f92fcdcbf6b65e37f1f5a13a9054b5b9e94",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/r/readline/readline-common_8.1.2-1_all.deb",
+			"version": "8.1.2-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
 					"key": "liblzma5_5.2.5-2ubuntu1_amd64",
 					"name": "liblzma5",
 					"version": "5.2.5-2ubuntu1"
@@ -895,6 +1558,2302 @@
 			"sha256": "6b5dff988d74cc9b52eaca0c2f843f2330dcdccf981f88d8181009dd3881a7ba",
 			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/x/xz-utils/xz-utils_5.2.5-2ubuntu1_amd64.deb",
 			"version": "5.2.5-2ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "lsb-base_11.1.0ubuntu4_amd64",
+					"name": "lsb-base",
+					"version": "11.1.0ubuntu4"
+				},
+				{
+					"key": "libpam-modules_1.4.0-11ubuntu2.4_amd64",
+					"name": "libpam-modules",
+					"version": "1.4.0-11ubuntu2.4"
+				},
+				{
+					"key": "libpam-modules-bin_1.4.0-11ubuntu2.4_amd64",
+					"name": "libpam-modules-bin",
+					"version": "1.4.0-11ubuntu2.4"
+				},
+				{
+					"key": "libselinux1_3.3-1build2_amd64",
+					"name": "libselinux1",
+					"version": "3.3-1build2"
+				},
+				{
+					"key": "libpcre2-8-0_10.39-3ubuntu0.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.39-3ubuntu0.1"
+				},
+				{
+					"key": "libc6_2.35-0ubuntu3.8_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3.8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libgcc-s1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libgcc-s1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "gcc-12-base_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "gcc-12-base",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "libpam0g_1.4.0-11ubuntu2.4_amd64",
+					"name": "libpam0g",
+					"version": "1.4.0-11ubuntu2.4"
+				},
+				{
+					"key": "libaudit1_1-3.0.7-1build1_amd64",
+					"name": "libaudit1",
+					"version": "1:3.0.7-1build1"
+				},
+				{
+					"key": "libcap-ng0_0.7.9-2.2build3_amd64",
+					"name": "libcap-ng0",
+					"version": "0.7.9-2.2build3"
+				},
+				{
+					"key": "libaudit-common_1-3.0.7-1build1_amd64",
+					"name": "libaudit-common",
+					"version": "1:3.0.7-1build1"
+				},
+				{
+					"key": "libtirpc3_1.3.2-2ubuntu0.1_amd64",
+					"name": "libtirpc3",
+					"version": "1.3.2-2ubuntu0.1"
+				},
+				{
+					"key": "libtirpc-common_1.3.2-2ubuntu0.1_amd64",
+					"name": "libtirpc-common",
+					"version": "1.3.2-2ubuntu0.1"
+				},
+				{
+					"key": "libgssapi-krb5-2_1.19.2-2ubuntu0.4_amd64",
+					"name": "libgssapi-krb5-2",
+					"version": "1.19.2-2ubuntu0.4"
+				},
+				{
+					"key": "libkrb5support0_1.19.2-2ubuntu0.4_amd64",
+					"name": "libkrb5support0",
+					"version": "1.19.2-2ubuntu0.4"
+				},
+				{
+					"key": "libkrb5-3_1.19.2-2ubuntu0.4_amd64",
+					"name": "libkrb5-3",
+					"version": "1.19.2-2ubuntu0.4"
+				},
+				{
+					"key": "libssl3_3.0.2-0ubuntu1.17_amd64",
+					"name": "libssl3",
+					"version": "3.0.2-0ubuntu1.17"
+				},
+				{
+					"key": "libkeyutils1_1.6.1-2ubuntu3_amd64",
+					"name": "libkeyutils1",
+					"version": "1.6.1-2ubuntu3"
+				},
+				{
+					"key": "libk5crypto3_1.19.2-2ubuntu0.4_amd64",
+					"name": "libk5crypto3",
+					"version": "1.19.2-2ubuntu0.4"
+				},
+				{
+					"key": "libcom-err2_1.46.5-2ubuntu1.2_amd64",
+					"name": "libcom-err2",
+					"version": "1.46.5-2ubuntu1.2"
+				},
+				{
+					"key": "libnsl2_1.3.0-2build2_amd64",
+					"name": "libnsl2",
+					"version": "1.3.0-2build2"
+				},
+				{
+					"key": "libdb5.3_5.3.28-p-dfsg1-0.8ubuntu3_amd64",
+					"name": "libdb5.3",
+					"version": "5.3.28+dfsg1-0.8ubuntu3"
+				},
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2ubuntu9.2_amd64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2ubuntu9.2"
+				}
+			],
+			"key": "sudo_1.9.9-1ubuntu2.4_amd64",
+			"name": "sudo",
+			"sha256": "42638252009ddc23e707dda08fad948c85ed925f2df8fdc1e3d8353d61a920f3",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/s/sudo/sudo_1.9.9-1ubuntu2.4_amd64.deb",
+			"version": "1.9.9-1ubuntu2.4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "lsb-base_11.1.0ubuntu4_amd64",
+			"name": "lsb-base",
+			"sha256": "23ac3e99b0c2cd0179a7f40fa5a24248345e16c515f222164dad2a638b4f04cf",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/l/lsb/lsb-base_11.1.0ubuntu4_all.deb",
+			"version": "11.1.0ubuntu4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpam-modules_1.4.0-11ubuntu2.4_amd64",
+			"name": "libpam-modules",
+			"sha256": "9fb26ec4a56f962f132c5123a9172a2bdbbcf7f670da25ddf0ca41bac7be7abf",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/pam/libpam-modules_1.4.0-11ubuntu2.4_amd64.deb",
+			"version": "1.4.0-11ubuntu2.4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpam-modules-bin_1.4.0-11ubuntu2.4_amd64",
+			"name": "libpam-modules-bin",
+			"sha256": "084193b1ab9f2b458cbb9d6ad130f27733f40ff4dfca5bc414a9bcccb89a7e18",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/pam/libpam-modules-bin_1.4.0-11ubuntu2.4_amd64.deb",
+			"version": "1.4.0-11ubuntu2.4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpam0g_1.4.0-11ubuntu2.4_amd64",
+			"name": "libpam0g",
+			"sha256": "287da5533ba14c7effe0416e44c5c1123fd04b53a5107dea9bcaab36fb4efaa8",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/pam/libpam0g_1.4.0-11ubuntu2.4_amd64.deb",
+			"version": "1.4.0-11ubuntu2.4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libaudit1_1-3.0.7-1build1_amd64",
+			"name": "libaudit1",
+			"sha256": "36710fbc49150a13f14f1f9c2c8288ee840cf9425f8a609c22fefa6b64eb51c1",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/a/audit/libaudit1_3.0.7-1build1_amd64.deb",
+			"version": "1:3.0.7-1build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcap-ng0_0.7.9-2.2build3_amd64",
+			"name": "libcap-ng0",
+			"sha256": "124d0c8748a841f279e996298ef8aac69a249e294792f4b5e16dc00496f1d3ac",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/libc/libcap-ng/libcap-ng0_0.7.9-2.2build3_amd64.deb",
+			"version": "0.7.9-2.2build3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libaudit-common_1-3.0.7-1build1_amd64",
+			"name": "libaudit-common",
+			"sha256": "86697036d05c956b5b42339bf61ecf3743f7c6fd4d59a67ab16add9a2cd7802a",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/a/audit/libaudit-common_3.0.7-1build1_all.deb",
+			"version": "1:3.0.7-1build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libtirpc3_1.3.2-2ubuntu0.1_amd64",
+			"name": "libtirpc3",
+			"sha256": "f2f07d1ab8ae8a8a6e893975df0bca8683caec516e7a30e8dadbb87d33aa52c4",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/libt/libtirpc/libtirpc3_1.3.2-2ubuntu0.1_amd64.deb",
+			"version": "1.3.2-2ubuntu0.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libtirpc-common_1.3.2-2ubuntu0.1_amd64",
+			"name": "libtirpc-common",
+			"sha256": "cd7b220447999402e87d75f7cedcfad159a2e5d4236927a414d77f2932219bee",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/libt/libtirpc/libtirpc-common_1.3.2-2ubuntu0.1_all.deb",
+			"version": "1.3.2-2ubuntu0.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnsl2_1.3.0-2build2_amd64",
+			"name": "libnsl2",
+			"sha256": "cfeef478f96ace59617f4f93c2497776b98a33c99bf3602af46844ccf9cba9d3",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/libn/libnsl/libnsl2_1.3.0-2build2_amd64.deb",
+			"version": "1.3.0-2build2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "distro-info-data_0.52ubuntu0.7_amd64",
+					"name": "distro-info-data",
+					"version": "0.52ubuntu0.7"
+				},
+				{
+					"key": "python3_3.10.6-1_22.04.1_amd64",
+					"name": "python3",
+					"version": "3.10.6-1~22.04.1"
+				},
+				{
+					"key": "libpython3-stdlib_3.10.6-1_22.04.1_amd64",
+					"name": "libpython3-stdlib",
+					"version": "3.10.6-1~22.04.1"
+				},
+				{
+					"key": "libpython3.10-stdlib_3.10.12-1_22.04.5_amd64",
+					"name": "libpython3.10-stdlib",
+					"version": "3.10.12-1~22.04.5"
+				},
+				{
+					"key": "libuuid1_2.37.2-4ubuntu3.4_amd64",
+					"name": "libuuid1",
+					"version": "2.37.2-4ubuntu3.4"
+				},
+				{
+					"key": "libc6_2.35-0ubuntu3.8_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3.8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libgcc-s1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libgcc-s1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "gcc-12-base_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "gcc-12-base",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "libtirpc3_1.3.2-2ubuntu0.1_amd64",
+					"name": "libtirpc3",
+					"version": "1.3.2-2ubuntu0.1"
+				},
+				{
+					"key": "libtirpc-common_1.3.2-2ubuntu0.1_amd64",
+					"name": "libtirpc-common",
+					"version": "1.3.2-2ubuntu0.1"
+				},
+				{
+					"key": "libgssapi-krb5-2_1.19.2-2ubuntu0.4_amd64",
+					"name": "libgssapi-krb5-2",
+					"version": "1.19.2-2ubuntu0.4"
+				},
+				{
+					"key": "libkrb5support0_1.19.2-2ubuntu0.4_amd64",
+					"name": "libkrb5support0",
+					"version": "1.19.2-2ubuntu0.4"
+				},
+				{
+					"key": "libkrb5-3_1.19.2-2ubuntu0.4_amd64",
+					"name": "libkrb5-3",
+					"version": "1.19.2-2ubuntu0.4"
+				},
+				{
+					"key": "libssl3_3.0.2-0ubuntu1.17_amd64",
+					"name": "libssl3",
+					"version": "3.0.2-0ubuntu1.17"
+				},
+				{
+					"key": "libkeyutils1_1.6.1-2ubuntu3_amd64",
+					"name": "libkeyutils1",
+					"version": "1.6.1-2ubuntu3"
+				},
+				{
+					"key": "libk5crypto3_1.19.2-2ubuntu0.4_amd64",
+					"name": "libk5crypto3",
+					"version": "1.19.2-2ubuntu0.4"
+				},
+				{
+					"key": "libcom-err2_1.46.5-2ubuntu1.2_amd64",
+					"name": "libcom-err2",
+					"version": "1.46.5-2ubuntu1.2"
+				},
+				{
+					"key": "libtinfo6_6.3-2ubuntu0.1_amd64",
+					"name": "libtinfo6",
+					"version": "6.3-2ubuntu0.1"
+				},
+				{
+					"key": "libsqlite3-0_3.37.2-2ubuntu0.3_amd64",
+					"name": "libsqlite3-0",
+					"version": "3.37.2-2ubuntu0.3"
+				},
+				{
+					"key": "libreadline8_8.1.2-1_amd64",
+					"name": "libreadline8",
+					"version": "8.1.2-1"
+				},
+				{
+					"key": "readline-common_8.1.2-1_amd64",
+					"name": "readline-common",
+					"version": "8.1.2-1"
+				},
+				{
+					"key": "libnsl2_1.3.0-2build2_amd64",
+					"name": "libnsl2",
+					"version": "1.3.0-2build2"
+				},
+				{
+					"key": "libncursesw6_6.3-2ubuntu0.1_amd64",
+					"name": "libncursesw6",
+					"version": "6.3-2ubuntu0.1"
+				},
+				{
+					"key": "libmpdec3_2.5.1-2build2_amd64",
+					"name": "libmpdec3",
+					"version": "2.5.1-2build2"
+				},
+				{
+					"key": "libstdc-p--p-6_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libstdc++6",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "liblzma5_5.2.5-2ubuntu1_amd64",
+					"name": "liblzma5",
+					"version": "5.2.5-2ubuntu1"
+				},
+				{
+					"key": "libffi8_3.4.2-4_amd64",
+					"name": "libffi8",
+					"version": "3.4.2-4"
+				},
+				{
+					"key": "libdb5.3_5.3.28-p-dfsg1-0.8ubuntu3_amd64",
+					"name": "libdb5.3",
+					"version": "5.3.28+dfsg1-0.8ubuntu3"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5build1_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5build1"
+				},
+				{
+					"key": "libpython3.10-minimal_3.10.12-1_22.04.5_amd64",
+					"name": "libpython3.10-minimal",
+					"version": "3.10.12-1~22.04.5"
+				},
+				{
+					"key": "python3.10_3.10.12-1_22.04.5_amd64",
+					"name": "python3.10",
+					"version": "3.10.12-1~22.04.5"
+				},
+				{
+					"key": "python3.10-minimal_3.10.12-1_22.04.5_amd64",
+					"name": "python3.10-minimal",
+					"version": "3.10.12-1~22.04.5"
+				},
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2ubuntu9.2_amd64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2ubuntu9.2"
+				},
+				{
+					"key": "libexpat1_2.4.7-1ubuntu0.3_amd64",
+					"name": "libexpat1",
+					"version": "2.4.7-1ubuntu0.3"
+				},
+				{
+					"key": "python3-minimal_3.10.6-1_22.04.1_amd64",
+					"name": "python3-minimal",
+					"version": "3.10.6-1~22.04.1"
+				},
+				{
+					"key": "dpkg_1.21.1ubuntu2.3_amd64",
+					"name": "dpkg",
+					"version": "1.21.1ubuntu2.3"
+				},
+				{
+					"key": "tar_1.34-p-dfsg-1ubuntu0.1.22.04.2_amd64",
+					"name": "tar",
+					"version": "1.34+dfsg-1ubuntu0.1.22.04.2"
+				},
+				{
+					"key": "libselinux1_3.3-1build2_amd64",
+					"name": "libselinux1",
+					"version": "3.3-1build2"
+				},
+				{
+					"key": "libpcre2-8-0_10.39-3ubuntu0.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.39-3ubuntu0.1"
+				},
+				{
+					"key": "libacl1_2.3.1-1_amd64",
+					"name": "libacl1",
+					"version": "2.3.1-1"
+				},
+				{
+					"key": "libzstd1_1.4.8-p-dfsg-3build1_amd64",
+					"name": "libzstd1",
+					"version": "1.4.8+dfsg-3build1"
+				}
+			],
+			"key": "lsb-release_11.1.0ubuntu4_amd64",
+			"name": "lsb-release",
+			"sha256": "184a61e14c3008a250aa639df938331e38d94778ddf5e8f8bb9182c76fee846c",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/l/lsb/lsb-release_11.1.0ubuntu4_all.deb",
+			"version": "11.1.0ubuntu4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "distro-info-data_0.52ubuntu0.7_amd64",
+			"name": "distro-info-data",
+			"sha256": "9d5bb8356f35c9817a18344f8c87b83e04e75dc1296d8afb198caa45a5172a77",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/d/distro-info-data/distro-info-data_0.52ubuntu0.7_all.deb",
+			"version": "0.52ubuntu0.7"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3_3.10.6-1_22.04.1_amd64",
+			"name": "python3",
+			"sha256": "43dbcc12d790ed9360be4a1dc690ac0a7464a5e7c3170785886df84811a3f5a5",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/python3-defaults/python3_3.10.6-1~22.04.1_amd64.deb",
+			"version": "3.10.6-1~22.04.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpython3-stdlib_3.10.6-1_22.04.1_amd64",
+			"name": "libpython3-stdlib",
+			"sha256": "41b8f285f0a1661ece778a63592dcb556710cce3c559d83114fad245bfdf56ea",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/python3-defaults/libpython3-stdlib_3.10.6-1~22.04.1_amd64.deb",
+			"version": "3.10.6-1~22.04.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpython3.10-stdlib_3.10.12-1_22.04.5_amd64",
+			"name": "libpython3.10-stdlib",
+			"sha256": "737f3cf14ea93904da2a3c4832724554aa05ef8cb5da054eb072e46b95e11fa3",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/python3.10/libpython3.10-stdlib_3.10.12-1~22.04.5_amd64.deb",
+			"version": "3.10.12-1~22.04.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libuuid1_2.37.2-4ubuntu3.4_amd64",
+			"name": "libuuid1",
+			"sha256": "3a88f3c8c58a32c623b79f1caace557f63cb997c03fa18eaa31ca0285f635919",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/u/util-linux/libuuid1_2.37.2-4ubuntu3.4_amd64.deb",
+			"version": "2.37.2-4ubuntu3.4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsqlite3-0_3.37.2-2ubuntu0.3_amd64",
+			"name": "libsqlite3-0",
+			"sha256": "b7d02794e49a06fe204f2fe519fb826b38f3828bff199939b6e5d64a0c43a96a",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/s/sqlite3/libsqlite3-0_3.37.2-2ubuntu0.3_amd64.deb",
+			"version": "3.37.2-2ubuntu0.3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libncursesw6_6.3-2ubuntu0.1_amd64",
+			"name": "libncursesw6",
+			"sha256": "88e5178ccdd4317e263dbe03db1a54a6e35ae1f1fd057585655c2b06ab487f6e",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/n/ncurses/libncursesw6_6.3-2ubuntu0.1_amd64.deb",
+			"version": "6.3-2ubuntu0.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libmpdec3_2.5.1-2build2_amd64",
+			"name": "libmpdec3",
+			"sha256": "941ca0b2e73d26522f75a801b1bf529afa5ceb2ac9b00cbf324b59f474cae813",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/m/mpdecimal/libmpdec3_2.5.1-2build2_amd64.deb",
+			"version": "2.5.1-2build2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpython3.10-minimal_3.10.12-1_22.04.5_amd64",
+			"name": "libpython3.10-minimal",
+			"sha256": "68621e2625ae3f2a5c76299019b66e26f551b868ab331f6c7c936a135459f7ce",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/python3.10/libpython3.10-minimal_3.10.12-1~22.04.5_amd64.deb",
+			"version": "3.10.12-1~22.04.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3.10_3.10.12-1_22.04.5_amd64",
+			"name": "python3.10",
+			"sha256": "cb868401dde0018af21114c376bc1ab1b43b1a5ab8061e92d6c68ab03879ecf8",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/python3.10/python3.10_3.10.12-1~22.04.5_amd64.deb",
+			"version": "3.10.12-1~22.04.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3.10-minimal_3.10.12-1_22.04.5_amd64",
+			"name": "python3.10-minimal",
+			"sha256": "a16f3089a4cdb5e1e92b585f6d1183922b63ff156c58b477f8db92e5154b23a0",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/python3.10/python3.10-minimal_3.10.12-1~22.04.5_amd64.deb",
+			"version": "3.10.12-1~22.04.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-minimal_3.10.6-1_22.04.1_amd64",
+			"name": "python3-minimal",
+			"sha256": "c2f9ebfa720344485d192f9b493065bee4a29d5021b093f9300c8101483de9dd",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/python3-defaults/python3-minimal_3.10.6-1~22.04.1_amd64.deb",
+			"version": "3.10.6-1~22.04.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libnpth0_1.6-3build2_amd64",
+					"name": "libnpth0",
+					"version": "1.6-3build2"
+				},
+				{
+					"key": "libc6_2.35-0ubuntu3.8_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3.8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libgcc-s1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libgcc-s1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "gcc-12-base_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "gcc-12-base",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "libgpg-error0_1.43-3_amd64",
+					"name": "libgpg-error0",
+					"version": "1.43-3"
+				},
+				{
+					"key": "libgcrypt20_1.9.4-3ubuntu3_amd64",
+					"name": "libgcrypt20",
+					"version": "1.9.4-3ubuntu3"
+				},
+				{
+					"key": "libassuan0_2.5.5-1build1_amd64",
+					"name": "libassuan0",
+					"version": "2.5.5-1build1"
+				},
+				{
+					"key": "init-system-helpers_1.62_amd64",
+					"name": "init-system-helpers",
+					"version": "1.62"
+				},
+				{
+					"key": "perl-base_5.34.0-3ubuntu1.3_amd64",
+					"name": "perl-base",
+					"version": "5.34.0-3ubuntu1.3"
+				},
+				{
+					"key": "dpkg_1.21.1ubuntu2.3_amd64",
+					"name": "dpkg",
+					"version": "1.21.1ubuntu2.3"
+				},
+				{
+					"key": "tar_1.34-p-dfsg-1ubuntu0.1.22.04.2_amd64",
+					"name": "tar",
+					"version": "1.34+dfsg-1ubuntu0.1.22.04.2"
+				},
+				{
+					"key": "libselinux1_3.3-1build2_amd64",
+					"name": "libselinux1",
+					"version": "3.3-1build2"
+				},
+				{
+					"key": "libpcre2-8-0_10.39-3ubuntu0.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.39-3ubuntu0.1"
+				},
+				{
+					"key": "libacl1_2.3.1-1_amd64",
+					"name": "libacl1",
+					"version": "2.3.1-1"
+				},
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2ubuntu9.2_amd64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2ubuntu9.2"
+				},
+				{
+					"key": "libzstd1_1.4.8-p-dfsg-3build1_amd64",
+					"name": "libzstd1",
+					"version": "1.4.8+dfsg-3build1"
+				},
+				{
+					"key": "liblzma5_5.2.5-2ubuntu1_amd64",
+					"name": "liblzma5",
+					"version": "5.2.5-2ubuntu1"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5build1_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5build1"
+				},
+				{
+					"key": "gpgconf_2.2.27-3ubuntu2.1_amd64",
+					"name": "gpgconf",
+					"version": "2.2.27-3ubuntu2.1"
+				},
+				{
+					"key": "libreadline8_8.1.2-1_amd64",
+					"name": "libreadline8",
+					"version": "8.1.2-1"
+				},
+				{
+					"key": "libtinfo6_6.3-2ubuntu0.1_amd64",
+					"name": "libtinfo6",
+					"version": "6.3-2ubuntu0.1"
+				},
+				{
+					"key": "readline-common_8.1.2-1_amd64",
+					"name": "readline-common",
+					"version": "8.1.2-1"
+				}
+			],
+			"key": "gpg-agent_2.2.27-3ubuntu2.1_amd64",
+			"name": "gpg-agent",
+			"sha256": "e67a6cc0e94e013c32126d1f7eb53b07feace8ee1b081df76b5f808034b613bc",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gnupg2/gpg-agent_2.2.27-3ubuntu2.1_amd64.deb",
+			"version": "2.2.27-3ubuntu2.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnpth0_1.6-3build2_amd64",
+			"name": "libnpth0",
+			"sha256": "e6e05ed1c4ccfbdc4ca3af2696dadbd0313b5287221ecafa306911da6fbbf89a",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/n/npth/libnpth0_1.6-3build2_amd64.deb",
+			"version": "1.6-3build2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgpg-error0_1.43-3_amd64",
+			"name": "libgpg-error0",
+			"sha256": "1fbacdf9bd1e431cee874a697b339f6f925182bc79bba5a112b53669b33265c5",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/libg/libgpg-error/libgpg-error0_1.43-3_amd64.deb",
+			"version": "1.43-3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgcrypt20_1.9.4-3ubuntu3_amd64",
+			"name": "libgcrypt20",
+			"sha256": "fe7d7e9f83b280f4fafaaa3852e462f43a9e854bc268e06667da2bf1b3e9d658",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/libg/libgcrypt20/libgcrypt20_1.9.4-3ubuntu3_amd64.deb",
+			"version": "1.9.4-3ubuntu3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libassuan0_2.5.5-1build1_amd64",
+			"name": "libassuan0",
+			"sha256": "5a7533e3e6d9ba4f0bee94c76de4e7947da87e3cc573cbf31d7e8e0a5640d024",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/liba/libassuan/libassuan0_2.5.5-1build1_amd64.deb",
+			"version": "2.5.5-1build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "init-system-helpers_1.62_amd64",
+			"name": "init-system-helpers",
+			"sha256": "810bc27b9b3cecab056d80d726de535ca68f00fcd955683bf46674d779f4e710",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/i/init-system-helpers/init-system-helpers_1.62_all.deb",
+			"version": "1.62"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "gpgconf_2.2.27-3ubuntu2.1_amd64",
+			"name": "gpgconf",
+			"sha256": "b712e3a294cfa37a710f438619d936eea502946fc3943ea2d3b8508114035ee9",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gnupg2/gpgconf_2.2.27-3ubuntu2.1_amd64.deb",
+			"version": "2.2.27-3ubuntu2.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "python3_3.10.6-1_22.04.1_amd64",
+					"name": "python3",
+					"version": "3.10.6-1~22.04.1"
+				},
+				{
+					"key": "libpython3-stdlib_3.10.6-1_22.04.1_amd64",
+					"name": "libpython3-stdlib",
+					"version": "3.10.6-1~22.04.1"
+				},
+				{
+					"key": "libpython3.10-stdlib_3.10.12-1_22.04.5_amd64",
+					"name": "libpython3.10-stdlib",
+					"version": "3.10.12-1~22.04.5"
+				},
+				{
+					"key": "libuuid1_2.37.2-4ubuntu3.4_amd64",
+					"name": "libuuid1",
+					"version": "2.37.2-4ubuntu3.4"
+				},
+				{
+					"key": "libc6_2.35-0ubuntu3.8_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3.8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libgcc-s1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libgcc-s1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "gcc-12-base_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "gcc-12-base",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "libtirpc3_1.3.2-2ubuntu0.1_amd64",
+					"name": "libtirpc3",
+					"version": "1.3.2-2ubuntu0.1"
+				},
+				{
+					"key": "libtirpc-common_1.3.2-2ubuntu0.1_amd64",
+					"name": "libtirpc-common",
+					"version": "1.3.2-2ubuntu0.1"
+				},
+				{
+					"key": "libgssapi-krb5-2_1.19.2-2ubuntu0.4_amd64",
+					"name": "libgssapi-krb5-2",
+					"version": "1.19.2-2ubuntu0.4"
+				},
+				{
+					"key": "libkrb5support0_1.19.2-2ubuntu0.4_amd64",
+					"name": "libkrb5support0",
+					"version": "1.19.2-2ubuntu0.4"
+				},
+				{
+					"key": "libkrb5-3_1.19.2-2ubuntu0.4_amd64",
+					"name": "libkrb5-3",
+					"version": "1.19.2-2ubuntu0.4"
+				},
+				{
+					"key": "libssl3_3.0.2-0ubuntu1.17_amd64",
+					"name": "libssl3",
+					"version": "3.0.2-0ubuntu1.17"
+				},
+				{
+					"key": "libkeyutils1_1.6.1-2ubuntu3_amd64",
+					"name": "libkeyutils1",
+					"version": "1.6.1-2ubuntu3"
+				},
+				{
+					"key": "libk5crypto3_1.19.2-2ubuntu0.4_amd64",
+					"name": "libk5crypto3",
+					"version": "1.19.2-2ubuntu0.4"
+				},
+				{
+					"key": "libcom-err2_1.46.5-2ubuntu1.2_amd64",
+					"name": "libcom-err2",
+					"version": "1.46.5-2ubuntu1.2"
+				},
+				{
+					"key": "libtinfo6_6.3-2ubuntu0.1_amd64",
+					"name": "libtinfo6",
+					"version": "6.3-2ubuntu0.1"
+				},
+				{
+					"key": "libsqlite3-0_3.37.2-2ubuntu0.3_amd64",
+					"name": "libsqlite3-0",
+					"version": "3.37.2-2ubuntu0.3"
+				},
+				{
+					"key": "libreadline8_8.1.2-1_amd64",
+					"name": "libreadline8",
+					"version": "8.1.2-1"
+				},
+				{
+					"key": "readline-common_8.1.2-1_amd64",
+					"name": "readline-common",
+					"version": "8.1.2-1"
+				},
+				{
+					"key": "libnsl2_1.3.0-2build2_amd64",
+					"name": "libnsl2",
+					"version": "1.3.0-2build2"
+				},
+				{
+					"key": "libncursesw6_6.3-2ubuntu0.1_amd64",
+					"name": "libncursesw6",
+					"version": "6.3-2ubuntu0.1"
+				},
+				{
+					"key": "libmpdec3_2.5.1-2build2_amd64",
+					"name": "libmpdec3",
+					"version": "2.5.1-2build2"
+				},
+				{
+					"key": "libstdc-p--p-6_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libstdc++6",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "liblzma5_5.2.5-2ubuntu1_amd64",
+					"name": "liblzma5",
+					"version": "5.2.5-2ubuntu1"
+				},
+				{
+					"key": "libffi8_3.4.2-4_amd64",
+					"name": "libffi8",
+					"version": "3.4.2-4"
+				},
+				{
+					"key": "libdb5.3_5.3.28-p-dfsg1-0.8ubuntu3_amd64",
+					"name": "libdb5.3",
+					"version": "5.3.28+dfsg1-0.8ubuntu3"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5build1_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5build1"
+				},
+				{
+					"key": "libpython3.10-minimal_3.10.12-1_22.04.5_amd64",
+					"name": "libpython3.10-minimal",
+					"version": "3.10.12-1~22.04.5"
+				},
+				{
+					"key": "python3.10_3.10.12-1_22.04.5_amd64",
+					"name": "python3.10",
+					"version": "3.10.12-1~22.04.5"
+				},
+				{
+					"key": "python3.10-minimal_3.10.12-1_22.04.5_amd64",
+					"name": "python3.10-minimal",
+					"version": "3.10.12-1~22.04.5"
+				},
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2ubuntu9.2_amd64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2ubuntu9.2"
+				},
+				{
+					"key": "libexpat1_2.4.7-1ubuntu0.3_amd64",
+					"name": "libexpat1",
+					"version": "2.4.7-1ubuntu0.3"
+				},
+				{
+					"key": "python3-minimal_3.10.6-1_22.04.1_amd64",
+					"name": "python3-minimal",
+					"version": "3.10.6-1~22.04.1"
+				},
+				{
+					"key": "dpkg_1.21.1ubuntu2.3_amd64",
+					"name": "dpkg",
+					"version": "1.21.1ubuntu2.3"
+				},
+				{
+					"key": "tar_1.34-p-dfsg-1ubuntu0.1.22.04.2_amd64",
+					"name": "tar",
+					"version": "1.34+dfsg-1ubuntu0.1.22.04.2"
+				},
+				{
+					"key": "libselinux1_3.3-1build2_amd64",
+					"name": "libselinux1",
+					"version": "3.3-1build2"
+				},
+				{
+					"key": "libpcre2-8-0_10.39-3ubuntu0.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.39-3ubuntu0.1"
+				},
+				{
+					"key": "libacl1_2.3.1-1_amd64",
+					"name": "libacl1",
+					"version": "2.3.1-1"
+				},
+				{
+					"key": "libzstd1_1.4.8-p-dfsg-3build1_amd64",
+					"name": "libzstd1",
+					"version": "1.4.8+dfsg-3build1"
+				},
+				{
+					"key": "python3-software-properties_0.99.22.9_amd64",
+					"name": "python3-software-properties",
+					"version": "0.99.22.9"
+				},
+				{
+					"key": "python3-launchpadlib_1.10.16-1_amd64",
+					"name": "python3-launchpadlib",
+					"version": "1.10.16-1"
+				},
+				{
+					"key": "python3-lazr.uri_1.0.6-2_amd64",
+					"name": "python3-lazr.uri",
+					"version": "1.0.6-2"
+				},
+				{
+					"key": "python3-pkg-resources_59.6.0-1.2ubuntu0.22.04.1_amd64",
+					"name": "python3-pkg-resources",
+					"version": "59.6.0-1.2ubuntu0.22.04.1"
+				},
+				{
+					"key": "python3-lazr.restfulclient_0.14.4-1_amd64",
+					"name": "python3-lazr.restfulclient",
+					"version": "0.14.4-1"
+				},
+				{
+					"key": "python3-six_1.16.0-3ubuntu1_amd64",
+					"name": "python3-six",
+					"version": "1.16.0-3ubuntu1"
+				},
+				{
+					"key": "python3-oauthlib_3.2.0-1ubuntu0.1_amd64",
+					"name": "python3-oauthlib",
+					"version": "3.2.0-1ubuntu0.1"
+				},
+				{
+					"key": "python3-jwt_2.3.0-1ubuntu0.2_amd64",
+					"name": "python3-jwt",
+					"version": "2.3.0-1ubuntu0.2"
+				},
+				{
+					"key": "python3-cryptography_3.4.8-1ubuntu2.2_amd64",
+					"name": "python3-cryptography",
+					"version": "3.4.8-1ubuntu2.2"
+				},
+				{
+					"key": "python3-blinker_1.4-p-dfsg1-0.4_amd64",
+					"name": "python3-blinker",
+					"version": "1.4+dfsg1-0.4"
+				},
+				{
+					"key": "python3-distro_1.7.0-1_amd64",
+					"name": "python3-distro",
+					"version": "1.7.0-1"
+				},
+				{
+					"key": "lsb-release_11.1.0ubuntu4_amd64",
+					"name": "lsb-release",
+					"version": "11.1.0ubuntu4"
+				},
+				{
+					"key": "distro-info-data_0.52ubuntu0.7_amd64",
+					"name": "distro-info-data",
+					"version": "0.52ubuntu0.7"
+				},
+				{
+					"key": "python3-wadllib_1.3.6-1_amd64",
+					"name": "python3-wadllib",
+					"version": "1.3.6-1"
+				},
+				{
+					"key": "python3-httplib2_0.20.2-2_amd64",
+					"name": "python3-httplib2",
+					"version": "0.20.2-2"
+				},
+				{
+					"key": "python3-pyparsing_2.4.7-1_amd64",
+					"name": "python3-pyparsing",
+					"version": "2.4.7-1"
+				},
+				{
+					"key": "ca-certificates_20230311ubuntu0.22.04.1_amd64",
+					"name": "ca-certificates",
+					"version": "20230311ubuntu0.22.04.1"
+				},
+				{
+					"key": "openssl_3.0.2-0ubuntu1.17_amd64",
+					"name": "openssl",
+					"version": "3.0.2-0ubuntu1.17"
+				},
+				{
+					"key": "python3-keyring_23.5.0-1_amd64",
+					"name": "python3-keyring",
+					"version": "23.5.0-1"
+				},
+				{
+					"key": "python3-secretstorage_3.3.1-1_amd64",
+					"name": "python3-secretstorage",
+					"version": "3.3.1-1"
+				},
+				{
+					"key": "python3-jeepney_0.7.1-3_amd64",
+					"name": "python3-jeepney",
+					"version": "0.7.1-3"
+				},
+				{
+					"key": "dbus_1.12.20-2ubuntu4.1_amd64",
+					"name": "dbus",
+					"version": "1.12.20-2ubuntu4.1"
+				},
+				{
+					"key": "libsystemd0_249.11-0ubuntu3.12_amd64",
+					"name": "libsystemd0",
+					"version": "249.11-0ubuntu3.12"
+				},
+				{
+					"key": "liblz4-1_1.9.3-2build2_amd64",
+					"name": "liblz4-1",
+					"version": "1.9.3-2build2"
+				},
+				{
+					"key": "libgcrypt20_1.9.4-3ubuntu3_amd64",
+					"name": "libgcrypt20",
+					"version": "1.9.4-3ubuntu3"
+				},
+				{
+					"key": "libgpg-error0_1.43-3_amd64",
+					"name": "libgpg-error0",
+					"version": "1.43-3"
+				},
+				{
+					"key": "libcap2_1-2.44-1ubuntu0.22.04.1_amd64",
+					"name": "libcap2",
+					"version": "1:2.44-1ubuntu0.22.04.1"
+				},
+				{
+					"key": "libdbus-1-3_1.12.20-2ubuntu4.1_amd64",
+					"name": "libdbus-1-3",
+					"version": "1.12.20-2ubuntu4.1"
+				},
+				{
+					"key": "libcap-ng0_0.7.9-2.2build3_amd64",
+					"name": "libcap-ng0",
+					"version": "0.7.9-2.2build3"
+				},
+				{
+					"key": "libaudit1_1-3.0.7-1build1_amd64",
+					"name": "libaudit1",
+					"version": "1:3.0.7-1build1"
+				},
+				{
+					"key": "libaudit-common_1-3.0.7-1build1_amd64",
+					"name": "libaudit-common",
+					"version": "1:3.0.7-1build1"
+				},
+				{
+					"key": "libapparmor1_3.0.4-2ubuntu2.3_amd64",
+					"name": "libapparmor1",
+					"version": "3.0.4-2ubuntu2.3"
+				},
+				{
+					"key": "adduser_3.118ubuntu5_amd64",
+					"name": "adduser",
+					"version": "3.118ubuntu5"
+				},
+				{
+					"key": "passwd_1-4.8.1-2ubuntu2.2_amd64",
+					"name": "passwd",
+					"version": "1:4.8.1-2ubuntu2.2"
+				},
+				{
+					"key": "libpam-modules_1.4.0-11ubuntu2.4_amd64",
+					"name": "libpam-modules",
+					"version": "1.4.0-11ubuntu2.4"
+				},
+				{
+					"key": "libpam-modules-bin_1.4.0-11ubuntu2.4_amd64",
+					"name": "libpam-modules-bin",
+					"version": "1.4.0-11ubuntu2.4"
+				},
+				{
+					"key": "libpam0g_1.4.0-11ubuntu2.4_amd64",
+					"name": "libpam0g",
+					"version": "1.4.0-11ubuntu2.4"
+				},
+				{
+					"key": "libsemanage2_3.3-1build2_amd64",
+					"name": "libsemanage2",
+					"version": "3.3-1build2"
+				},
+				{
+					"key": "libsepol2_3.3-1build1_amd64",
+					"name": "libsepol2",
+					"version": "3.3-1build1"
+				},
+				{
+					"key": "libsemanage-common_3.3-1build2_amd64",
+					"name": "libsemanage-common",
+					"version": "3.3-1build2"
+				},
+				{
+					"key": "python3-importlib-metadata_4.6.4-1_amd64",
+					"name": "python3-importlib-metadata",
+					"version": "4.6.4-1"
+				},
+				{
+					"key": "python3-zipp_1.0.0-3ubuntu0.1_amd64",
+					"name": "python3-zipp",
+					"version": "1.0.0-3ubuntu0.1"
+				},
+				{
+					"key": "python3-more-itertools_8.10.0-2_amd64",
+					"name": "python3-more-itertools",
+					"version": "8.10.0-2"
+				},
+				{
+					"key": "python3-gi_3.42.1-0ubuntu1_amd64",
+					"name": "python3-gi",
+					"version": "3.42.1-0ubuntu1"
+				},
+				{
+					"key": "libglib2.0-0_2.72.4-0ubuntu2.3_amd64",
+					"name": "libglib2.0-0",
+					"version": "2.72.4-0ubuntu2.3"
+				},
+				{
+					"key": "libpcre3_2-8.39-13ubuntu0.22.04.1_amd64",
+					"name": "libpcre3",
+					"version": "2:8.39-13ubuntu0.22.04.1"
+				},
+				{
+					"key": "libmount1_2.37.2-4ubuntu3.4_amd64",
+					"name": "libmount1",
+					"version": "2.37.2-4ubuntu3.4"
+				},
+				{
+					"key": "libblkid1_2.37.2-4ubuntu3.4_amd64",
+					"name": "libblkid1",
+					"version": "2.37.2-4ubuntu3.4"
+				},
+				{
+					"key": "libgirepository-1.0-1_1.72.0-1_amd64",
+					"name": "libgirepository-1.0-1",
+					"version": "1.72.0-1"
+				},
+				{
+					"key": "gir1.2-glib-2.0_1.72.0-1_amd64",
+					"name": "gir1.2-glib-2.0",
+					"version": "1.72.0-1"
+				},
+				{
+					"key": "python3-apt_2.4.0ubuntu3_amd64",
+					"name": "python3-apt",
+					"version": "2.4.0ubuntu3"
+				},
+				{
+					"key": "python-apt-common_2.4.0ubuntu3_amd64",
+					"name": "python-apt-common",
+					"version": "2.4.0ubuntu3"
+				},
+				{
+					"key": "libapt-pkg6.0_2.4.12_amd64",
+					"name": "libapt-pkg6.0",
+					"version": "2.4.12"
+				},
+				{
+					"key": "libxxhash0_0.8.1-1_amd64",
+					"name": "libxxhash0",
+					"version": "0.8.1-1"
+				},
+				{
+					"key": "libudev1_249.11-0ubuntu3.12_amd64",
+					"name": "libudev1",
+					"version": "249.11-0ubuntu3.12"
+				},
+				{
+					"key": "iso-codes_4.9.0-1_amd64",
+					"name": "iso-codes",
+					"version": "4.9.0-1"
+				},
+				{
+					"key": "gpg_2.2.27-3ubuntu2.1_amd64",
+					"name": "gpg",
+					"version": "2.2.27-3ubuntu2.1"
+				},
+				{
+					"key": "libassuan0_2.5.5-1build1_amd64",
+					"name": "libassuan0",
+					"version": "2.5.5-1build1"
+				},
+				{
+					"key": "gpgconf_2.2.27-3ubuntu2.1_amd64",
+					"name": "gpgconf",
+					"version": "2.2.27-3ubuntu2.1"
+				},
+				{
+					"key": "python3-dbus_1.2.18-3build1_amd64",
+					"name": "python3-dbus",
+					"version": "1.2.18-3build1"
+				},
+				{
+					"key": "packagekit_1.2.5-2ubuntu2_amd64",
+					"name": "packagekit",
+					"version": "1.2.5-2ubuntu2"
+				},
+				{
+					"key": "libpolkit-gobject-1-0_0.105-33_amd64",
+					"name": "libpolkit-gobject-1-0",
+					"version": "0.105-33"
+				},
+				{
+					"key": "libpackagekit-glib2-18_1.2.5-2ubuntu2_amd64",
+					"name": "libpackagekit-glib2-18",
+					"version": "1.2.5-2ubuntu2"
+				},
+				{
+					"key": "libgstreamer1.0-0_1.20.3-0ubuntu1_amd64",
+					"name": "libgstreamer1.0-0",
+					"version": "1.20.3-0ubuntu1"
+				},
+				{
+					"key": "libcap2-bin_1-2.44-1ubuntu0.22.04.1_amd64",
+					"name": "libcap2-bin",
+					"version": "1:2.44-1ubuntu0.22.04.1"
+				},
+				{
+					"key": "libunwind8_1.3.2-2build2.1_amd64",
+					"name": "libunwind8",
+					"version": "1.3.2-2build2.1"
+				},
+				{
+					"key": "libdw1_0.186-1build1_amd64",
+					"name": "libdw1",
+					"version": "0.186-1build1"
+				},
+				{
+					"key": "libelf1_0.186-1build1_amd64",
+					"name": "libelf1",
+					"version": "0.186-1build1"
+				},
+				{
+					"key": "libappstream4_0.15.2-2_amd64",
+					"name": "libappstream4",
+					"version": "0.15.2-2"
+				},
+				{
+					"key": "libyaml-0-2_0.2.2-1build2_amd64",
+					"name": "libyaml-0-2",
+					"version": "0.2.2-1build2"
+				},
+				{
+					"key": "libxmlb2_0.3.6-2build1_amd64",
+					"name": "libxmlb2",
+					"version": "0.3.6-2build1"
+				},
+				{
+					"key": "libxml2_2.9.13-p-dfsg-1ubuntu0.4_amd64",
+					"name": "libxml2",
+					"version": "2.9.13+dfsg-1ubuntu0.4"
+				},
+				{
+					"key": "libicu70_70.1-2_amd64",
+					"name": "libicu70",
+					"version": "70.1-2"
+				},
+				{
+					"key": "libstemmer0d_2.2.0-1build1_amd64",
+					"name": "libstemmer0d",
+					"version": "2.2.0-1build1"
+				},
+				{
+					"key": "libcurl3-gnutls_7.81.0-1ubuntu1.17_amd64",
+					"name": "libcurl3-gnutls",
+					"version": "7.81.0-1ubuntu1.17"
+				},
+				{
+					"key": "libssh-4_0.9.6-2ubuntu0.22.04.3_amd64",
+					"name": "libssh-4",
+					"version": "0.9.6-2ubuntu0.22.04.3"
+				},
+				{
+					"key": "librtmp1_2.4-p-20151223.gitfa8646d.1-2build4_amd64",
+					"name": "librtmp1",
+					"version": "2.4+20151223.gitfa8646d.1-2build4"
+				},
+				{
+					"key": "libnettle8_3.7.3-1build2_amd64",
+					"name": "libnettle8",
+					"version": "3.7.3-1build2"
+				},
+				{
+					"key": "libhogweed6_3.7.3-1build2_amd64",
+					"name": "libhogweed6",
+					"version": "3.7.3-1build2"
+				},
+				{
+					"key": "libgmp10_2-6.2.1-p-dfsg-3ubuntu1_amd64",
+					"name": "libgmp10",
+					"version": "2:6.2.1+dfsg-3ubuntu1"
+				},
+				{
+					"key": "libgnutls30_3.7.3-4ubuntu1.5_amd64",
+					"name": "libgnutls30",
+					"version": "3.7.3-4ubuntu1.5"
+				},
+				{
+					"key": "libunistring2_1.0-1_amd64",
+					"name": "libunistring2",
+					"version": "1.0-1"
+				},
+				{
+					"key": "libtasn1-6_4.18.0-4build1_amd64",
+					"name": "libtasn1-6",
+					"version": "4.18.0-4build1"
+				},
+				{
+					"key": "libp11-kit0_0.24.0-6build1_amd64",
+					"name": "libp11-kit0",
+					"version": "0.24.0-6build1"
+				},
+				{
+					"key": "libidn2-0_2.3.2-2build1_amd64",
+					"name": "libidn2-0",
+					"version": "2.3.2-2build1"
+				},
+				{
+					"key": "libpsl5_0.21.0-1.2build2_amd64",
+					"name": "libpsl5",
+					"version": "0.21.0-1.2build2"
+				},
+				{
+					"key": "libnghttp2-14_1.43.0-1ubuntu0.2_amd64",
+					"name": "libnghttp2-14",
+					"version": "1.43.0-1ubuntu0.2"
+				},
+				{
+					"key": "libldap-2.5-0_2.5.18-p-dfsg-0ubuntu0.22.04.2_amd64",
+					"name": "libldap-2.5-0",
+					"version": "2.5.18+dfsg-0ubuntu0.22.04.2"
+				},
+				{
+					"key": "libsasl2-2_2.1.27-p-dfsg2-3ubuntu1.2_amd64",
+					"name": "libsasl2-2",
+					"version": "2.1.27+dfsg2-3ubuntu1.2"
+				},
+				{
+					"key": "libsasl2-modules-db_2.1.27-p-dfsg2-3ubuntu1.2_amd64",
+					"name": "libsasl2-modules-db",
+					"version": "2.1.27+dfsg2-3ubuntu1.2"
+				},
+				{
+					"key": "libbrotli1_1.0.9-2build6_amd64",
+					"name": "libbrotli1",
+					"version": "1.0.9-2build6"
+				},
+				{
+					"key": "init-system-helpers_1.62_amd64",
+					"name": "init-system-helpers",
+					"version": "1.62"
+				},
+				{
+					"key": "perl-base_5.34.0-3ubuntu1.3_amd64",
+					"name": "perl-base",
+					"version": "5.34.0-3ubuntu1.3"
+				},
+				{
+					"key": "policykit-1_0.105-33_amd64",
+					"name": "policykit-1",
+					"version": "0.105-33"
+				},
+				{
+					"key": "polkitd_0.105-33_amd64",
+					"name": "polkitd",
+					"version": "0.105-33"
+				},
+				{
+					"key": "libpolkit-agent-1-0_0.105-33_amd64",
+					"name": "libpolkit-agent-1-0",
+					"version": "0.105-33"
+				},
+				{
+					"key": "pkexec_0.105-33_amd64",
+					"name": "pkexec",
+					"version": "0.105-33"
+				},
+				{
+					"key": "libglib2.0-bin_2.72.4-0ubuntu2.3_amd64",
+					"name": "libglib2.0-bin",
+					"version": "2.72.4-0ubuntu2.3"
+				},
+				{
+					"key": "libglib2.0-data_2.72.4-0ubuntu2.3_amd64",
+					"name": "libglib2.0-data",
+					"version": "2.72.4-0ubuntu2.3"
+				},
+				{
+					"key": "gir1.2-packagekitglib-1.0_1.2.5-2ubuntu2_amd64",
+					"name": "gir1.2-packagekitglib-1.0",
+					"version": "1.2.5-2ubuntu2"
+				}
+			],
+			"key": "software-properties-common_0.99.22.9_amd64",
+			"name": "software-properties-common",
+			"sha256": "bc173c0e9a2e98477b711730757c15da89de9e0ba10178aedf5180c0a2ca84ed",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/s/software-properties/software-properties-common_0.99.22.9_all.deb",
+			"version": "0.99.22.9"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-software-properties_0.99.22.9_amd64",
+			"name": "python3-software-properties",
+			"sha256": "ec5a4415ebf6c6fd00fed4b0a937e45f78ba3b7ded4ceceee5224f4d25d3967d",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/s/software-properties/python3-software-properties_0.99.22.9_all.deb",
+			"version": "0.99.22.9"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-launchpadlib_1.10.16-1_amd64",
+			"name": "python3-launchpadlib",
+			"sha256": "9e1903fc74a0315be4994b27e6544d0c28492c0391dd794b59ec250c6cb60e1c",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/python-launchpadlib/python3-launchpadlib_1.10.16-1_all.deb",
+			"version": "1.10.16-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-lazr.uri_1.0.6-2_amd64",
+			"name": "python3-lazr.uri",
+			"sha256": "afff7995e8bde81c4747cc074a87506ceb403ea145abdd8cec006d3b2430c02f",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/l/lazr.uri/python3-lazr.uri_1.0.6-2_all.deb",
+			"version": "1.0.6-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-pkg-resources_59.6.0-1.2ubuntu0.22.04.1_amd64",
+			"name": "python3-pkg-resources",
+			"sha256": "2cecc9e3b52937747b14f51d8478ad8107781b26380ca4acde7f85674c9fcf33",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/s/setuptools/python3-pkg-resources_59.6.0-1.2ubuntu0.22.04.1_all.deb",
+			"version": "59.6.0-1.2ubuntu0.22.04.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-lazr.restfulclient_0.14.4-1_amd64",
+			"name": "python3-lazr.restfulclient",
+			"sha256": "85eaef8f43d5850a3a53fdcbc854b7ade90a85d6f88ad5fca4550adb7c1cce4c",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/l/lazr.restfulclient/python3-lazr.restfulclient_0.14.4-1_all.deb",
+			"version": "0.14.4-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-six_1.16.0-3ubuntu1_amd64",
+			"name": "python3-six",
+			"sha256": "561db46fbee989a595ef4be588cd4ecbe76ca19bdbfe93d7d006b07acb53e4ea",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/s/six/python3-six_1.16.0-3ubuntu1_all.deb",
+			"version": "1.16.0-3ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-oauthlib_3.2.0-1ubuntu0.1_amd64",
+			"name": "python3-oauthlib",
+			"sha256": "db7e2ac9eae6f66583cd10bb2a890233a22bbef432d70433080076eacc901fa4",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/python-oauthlib/python3-oauthlib_3.2.0-1ubuntu0.1_all.deb",
+			"version": "3.2.0-1ubuntu0.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-jwt_2.3.0-1ubuntu0.2_amd64",
+			"name": "python3-jwt",
+			"sha256": "77e245c384592e55012819b8dbdb8a9751aa21108fdedda808c6ef547135034f",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/pyjwt/python3-jwt_2.3.0-1ubuntu0.2_all.deb",
+			"version": "2.3.0-1ubuntu0.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-cryptography_3.4.8-1ubuntu2.2_amd64",
+			"name": "python3-cryptography",
+			"sha256": "0dfce1c88af5d598a70fa284d04c49a8b3b4df3e338a8cdb1ff8b5dd71ddc702",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/python-cryptography/python3-cryptography_3.4.8-1ubuntu2.2_amd64.deb",
+			"version": "3.4.8-1ubuntu2.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-blinker_1.4-p-dfsg1-0.4_amd64",
+			"name": "python3-blinker",
+			"sha256": "c0964a1414b9d4f8bf6d51895e08eba1d6df57f59ba2f571be1cf07ceb378a99",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/b/blinker/python3-blinker_1.4+dfsg1-0.4_all.deb",
+			"version": "1.4+dfsg1-0.4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-distro_1.7.0-1_amd64",
+			"name": "python3-distro",
+			"sha256": "6a5e72cf879d9e795cd4f4760fbb597d55def7e545344ba6f8876eec0c4c92c6",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/python-distro/python3-distro_1.7.0-1_all.deb",
+			"version": "1.7.0-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-wadllib_1.3.6-1_amd64",
+			"name": "python3-wadllib",
+			"sha256": "e6185d1d91d173ab10f0287e0d93688235c20b4534c6b3bbdc3a76dc95f569e2",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/python-wadllib/python3-wadllib_1.3.6-1_all.deb",
+			"version": "1.3.6-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-httplib2_0.20.2-2_amd64",
+			"name": "python3-httplib2",
+			"sha256": "a296eb7913e15a1c223b88b2103e804be71cc09030ddb72f0c206f06732e8563",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/python-httplib2/python3-httplib2_0.20.2-2_all.deb",
+			"version": "0.20.2-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-pyparsing_2.4.7-1_amd64",
+			"name": "python3-pyparsing",
+			"sha256": "b28bcfb1cf7992e1802c41b659535646cd86dd20cc62adcf941bb095005a45a4",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/pyparsing/python3-pyparsing_2.4.7-1_all.deb",
+			"version": "2.4.7-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-keyring_23.5.0-1_amd64",
+			"name": "python3-keyring",
+			"sha256": "b76dd36c171348a67053dc1e1e54ff8ecf50d6060d4dffb0f740e21e6a16a1f5",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/python-keyring/python3-keyring_23.5.0-1_all.deb",
+			"version": "23.5.0-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-secretstorage_3.3.1-1_amd64",
+			"name": "python3-secretstorage",
+			"sha256": "32e9dd98817bab04ac752623ab9ffd53733d320042ed32561fa57b9e7e855031",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/python-secretstorage/python3-secretstorage_3.3.1-1_all.deb",
+			"version": "3.3.1-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-jeepney_0.7.1-3_amd64",
+			"name": "python3-jeepney",
+			"sha256": "bc608c8bf37b7d40b3b3ee7018efbcf2fa8ccfe64be303b2144e5ce9560dbc70",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/j/jeepney/python3-jeepney_0.7.1-3_all.deb",
+			"version": "0.7.1-3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "dbus_1.12.20-2ubuntu4.1_amd64",
+			"name": "dbus",
+			"sha256": "e75f70b0104cdee8fc03d5f7d4bf1ca433de3abba6c40b44a8f34e1c981a56fb",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/d/dbus/dbus_1.12.20-2ubuntu4.1_amd64.deb",
+			"version": "1.12.20-2ubuntu4.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsystemd0_249.11-0ubuntu3.12_amd64",
+			"name": "libsystemd0",
+			"sha256": "e1c90c12ce39edd04fd2648baad999e63e5fc122a5f94ddc88bd8f445f8a0b4b",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/s/systemd/libsystemd0_249.11-0ubuntu3.12_amd64.deb",
+			"version": "249.11-0ubuntu3.12"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "liblz4-1_1.9.3-2build2_amd64",
+			"name": "liblz4-1",
+			"sha256": "ac9b54d0feb840345060c74fb687675c5e1eb2b195effafae38c5f9991041e98",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/l/lz4/liblz4-1_1.9.3-2build2_amd64.deb",
+			"version": "1.9.3-2build2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcap2_1-2.44-1ubuntu0.22.04.1_amd64",
+			"name": "libcap2",
+			"sha256": "b5c190b0094512bea830fff3891f10c5e098487b6869b5d0c15e660c2837f7a5",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/libc/libcap2/libcap2_2.44-1ubuntu0.22.04.1_amd64.deb",
+			"version": "1:2.44-1ubuntu0.22.04.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libdbus-1-3_1.12.20-2ubuntu4.1_amd64",
+			"name": "libdbus-1-3",
+			"sha256": "6a5171696c3b05aca273d637d9c0501c8033fda64a971e09fd545bc1ab72ca1e",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/d/dbus/libdbus-1-3_1.12.20-2ubuntu4.1_amd64.deb",
+			"version": "1.12.20-2ubuntu4.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libapparmor1_3.0.4-2ubuntu2.3_amd64",
+			"name": "libapparmor1",
+			"sha256": "1f94a90f89e2ab4b4215a2012d2b062ce3d560189711518a4906df5fca7966c5",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/a/apparmor/libapparmor1_3.0.4-2ubuntu2.3_amd64.deb",
+			"version": "3.0.4-2ubuntu2.3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "adduser_3.118ubuntu5_amd64",
+			"name": "adduser",
+			"sha256": "53c30389227d4d16f1108a1df7ae1540c890378318335d1dc7ee95b7257f1f17",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/a/adduser/adduser_3.118ubuntu5_all.deb",
+			"version": "3.118ubuntu5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "passwd_1-4.8.1-2ubuntu2.2_amd64",
+			"name": "passwd",
+			"sha256": "825a5756013fbb2217b244b2fd6bef7ed10d037f1d8abd6b25fc9ea1c42a7576",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/s/shadow/passwd_4.8.1-2ubuntu2.2_amd64.deb",
+			"version": "1:4.8.1-2ubuntu2.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsemanage2_3.3-1build2_amd64",
+			"name": "libsemanage2",
+			"sha256": "0ab2748fce09293ca2c4c1214460409f834be1736ec1b1841927302efd8fa9da",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/libs/libsemanage/libsemanage2_3.3-1build2_amd64.deb",
+			"version": "3.3-1build2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsepol2_3.3-1build1_amd64",
+			"name": "libsepol2",
+			"sha256": "d47b019f21865a9692e361d260e96a3234fd934cee37026dad8f41228d9363d8",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/libs/libsepol/libsepol2_3.3-1build1_amd64.deb",
+			"version": "3.3-1build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsemanage-common_3.3-1build2_amd64",
+			"name": "libsemanage-common",
+			"sha256": "bb60d1049ed3d7838b395785cab09f2210c04878fcae9391ea3499f62d04ec2d",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/libs/libsemanage/libsemanage-common_3.3-1build2_all.deb",
+			"version": "3.3-1build2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-importlib-metadata_4.6.4-1_amd64",
+			"name": "python3-importlib-metadata",
+			"sha256": "36091862c20f959e68da02b0d923613fbd2af3eccc3165c2d3b52cb339440237",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/python-importlib-metadata/python3-importlib-metadata_4.6.4-1_all.deb",
+			"version": "4.6.4-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-zipp_1.0.0-3ubuntu0.1_amd64",
+			"name": "python3-zipp",
+			"sha256": "65baee4eaa0ff256c3d63644833fc83812bd669e8fd7a093bb4936c802a31429",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/python-zipp/python3-zipp_1.0.0-3ubuntu0.1_all.deb",
+			"version": "1.0.0-3ubuntu0.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-more-itertools_8.10.0-2_amd64",
+			"name": "python3-more-itertools",
+			"sha256": "acf021afdac9553e0b1d45ea8d3012be3830cf80df7907d78d17e90dee904b3e",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/m/more-itertools/python3-more-itertools_8.10.0-2_all.deb",
+			"version": "8.10.0-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-gi_3.42.1-0ubuntu1_amd64",
+			"name": "python3-gi",
+			"sha256": "718c601d9df7bfc23d9daf9aad5dd2473115e0e5bf69c6bcfa88f41815ec9b7e",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/pygobject/python3-gi_3.42.1-0ubuntu1_amd64.deb",
+			"version": "3.42.1-0ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libglib2.0-0_2.72.4-0ubuntu2.3_amd64",
+			"name": "libglib2.0-0",
+			"sha256": "40e04e6b7a89802ebb7bdb951584d3da828d219058b704ebd9d33f2f527baa74",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/glib2.0/libglib2.0-0_2.72.4-0ubuntu2.3_amd64.deb",
+			"version": "2.72.4-0ubuntu2.3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpcre3_2-8.39-13ubuntu0.22.04.1_amd64",
+			"name": "libpcre3",
+			"sha256": "0d1eb051047eb0c637c893f618f45e1d419863bfa3bc821897ee05ad418ba22e",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/pcre3/libpcre3_8.39-13ubuntu0.22.04.1_amd64.deb",
+			"version": "2:8.39-13ubuntu0.22.04.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libmount1_2.37.2-4ubuntu3.4_amd64",
+			"name": "libmount1",
+			"sha256": "24f6ad7ecc0cc4a84252adbc3833c17d67ee79084881baad31207d27cc5533c4",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/u/util-linux/libmount1_2.37.2-4ubuntu3.4_amd64.deb",
+			"version": "2.37.2-4ubuntu3.4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libblkid1_2.37.2-4ubuntu3.4_amd64",
+			"name": "libblkid1",
+			"sha256": "22d833190137632c75b60e5572ccae111187f293ae9ea38f204a28856ce6fdb2",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/u/util-linux/libblkid1_2.37.2-4ubuntu3.4_amd64.deb",
+			"version": "2.37.2-4ubuntu3.4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgirepository-1.0-1_1.72.0-1_amd64",
+			"name": "libgirepository-1.0-1",
+			"sha256": "2564342ced21cd09786ab7af1bb66c384fc183c05e1dce1b1bbcf0313f1998c6",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gobject-introspection/libgirepository-1.0-1_1.72.0-1_amd64.deb",
+			"version": "1.72.0-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "gir1.2-glib-2.0_1.72.0-1_amd64",
+			"name": "gir1.2-glib-2.0",
+			"sha256": "7d4f3aa077ff0358ab34cea1298f2b99990ebc6a4ed81fadd73bd4a846f6976c",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gobject-introspection/gir1.2-glib-2.0_1.72.0-1_amd64.deb",
+			"version": "1.72.0-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-apt_2.4.0ubuntu3_amd64",
+			"name": "python3-apt",
+			"sha256": "6e8a1e138a1c4db3d38acb5c324fefa7ac19735fb2ae1974264f0fea733bcf5b",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/python-apt/python3-apt_2.4.0ubuntu3_amd64.deb",
+			"version": "2.4.0ubuntu3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python-apt-common_2.4.0ubuntu3_amd64",
+			"name": "python-apt-common",
+			"sha256": "dcbf6e99d69186d2c85d8ff639350ad2178eb24ff0ff20c91632b933af159dba",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/python-apt/python-apt-common_2.4.0ubuntu3_all.deb",
+			"version": "2.4.0ubuntu3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libapt-pkg6.0_2.4.12_amd64",
+			"name": "libapt-pkg6.0",
+			"sha256": "70c92006bafbb4399b00eaf9149bad36d2436b10fbec28f62a797a5b2101c3fe",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/a/apt/libapt-pkg6.0_2.4.12_amd64.deb",
+			"version": "2.4.12"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libxxhash0_0.8.1-1_amd64",
+			"name": "libxxhash0",
+			"sha256": "71cf4300213c7ce65deadf37a21dc250d8162cdf1e41d7fda1e279a390051169",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/x/xxhash/libxxhash0_0.8.1-1_amd64.deb",
+			"version": "0.8.1-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libudev1_249.11-0ubuntu3.12_amd64",
+			"name": "libudev1",
+			"sha256": "64b5fb52b4a66bc17aa791ae9814b1eef017e169ce09191027151e3511f2b7ff",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/s/systemd/libudev1_249.11-0ubuntu3.12_amd64.deb",
+			"version": "249.11-0ubuntu3.12"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "iso-codes_4.9.0-1_amd64",
+			"name": "iso-codes",
+			"sha256": "16ac9fefc100991bfc3f6d576ac3646c5a3c9651cfc6d849c3b676be0f4ea0a2",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/i/iso-codes/iso-codes_4.9.0-1_all.deb",
+			"version": "4.9.0-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "gpg_2.2.27-3ubuntu2.1_amd64",
+			"name": "gpg",
+			"sha256": "a2b3004c6ecd5b95e5f89ef37074eb28a06d1b95780ae8a7906f3975d2278bfd",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gnupg2/gpg_2.2.27-3ubuntu2.1_amd64.deb",
+			"version": "2.2.27-3ubuntu2.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-dbus_1.2.18-3build1_amd64",
+			"name": "python3-dbus",
+			"sha256": "c6f4ca7fba69485cf5e4f3272a21d5836a79f6c77b87eff983983faacff497ea",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/d/dbus-python/python3-dbus_1.2.18-3build1_amd64.deb",
+			"version": "1.2.18-3build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "packagekit_1.2.5-2ubuntu2_amd64",
+			"name": "packagekit",
+			"sha256": "f6d6eed75721ea6de39789250cb7e3fa821f31812e61ad8cab3d7a53e756d1e8",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/packagekit/packagekit_1.2.5-2ubuntu2_amd64.deb",
+			"version": "1.2.5-2ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpolkit-gobject-1-0_0.105-33_amd64",
+			"name": "libpolkit-gobject-1-0",
+			"sha256": "2e1b0b30ce1767c422cc79a5586e3cf63efc5184424f467e756fdbab559578fa",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/policykit-1/libpolkit-gobject-1-0_0.105-33_amd64.deb",
+			"version": "0.105-33"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpackagekit-glib2-18_1.2.5-2ubuntu2_amd64",
+			"name": "libpackagekit-glib2-18",
+			"sha256": "024ebec5572f68fc66f24f72af683076f578a1e4bd91f1b290033bce73c65c47",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/packagekit/libpackagekit-glib2-18_1.2.5-2ubuntu2_amd64.deb",
+			"version": "1.2.5-2ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgstreamer1.0-0_1.20.3-0ubuntu1_amd64",
+			"name": "libgstreamer1.0-0",
+			"sha256": "9f89db149564ca14c3576c589bce7951fad1250294e0f79597ba3ab7574cb2a4",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gstreamer1.0/libgstreamer1.0-0_1.20.3-0ubuntu1_amd64.deb",
+			"version": "1.20.3-0ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcap2-bin_1-2.44-1ubuntu0.22.04.1_amd64",
+			"name": "libcap2-bin",
+			"sha256": "d20ef244eeb794dd047fd46dc62d41b31ded20549e3d0a6b99b5c9a28c304076",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/libc/libcap2/libcap2-bin_2.44-1ubuntu0.22.04.1_amd64.deb",
+			"version": "1:2.44-1ubuntu0.22.04.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libunwind8_1.3.2-2build2.1_amd64",
+			"name": "libunwind8",
+			"sha256": "781e3eb86986ab93e8b4866fc571fdec780c3d9a8b56b490e9c2f10fb90978ce",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/libu/libunwind/libunwind8_1.3.2-2build2.1_amd64.deb",
+			"version": "1.3.2-2build2.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libdw1_0.186-1build1_amd64",
+			"name": "libdw1",
+			"sha256": "ec6eff38e81bcaa462b09e18c2a7972e7b2e1cac24268424a6cf87b010a10704",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/e/elfutils/libdw1_0.186-1build1_amd64.deb",
+			"version": "0.186-1build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libelf1_0.186-1build1_amd64",
+			"name": "libelf1",
+			"sha256": "8effc4d7a0cc341bcf6cb11af0134f3defa6292376ecfdfc697a9b228606345c",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/e/elfutils/libelf1_0.186-1build1_amd64.deb",
+			"version": "0.186-1build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libappstream4_0.15.2-2_amd64",
+			"name": "libappstream4",
+			"sha256": "06b6ff67f5899849ff5d04745e7c855aee5cc6d3e868fe270e7428f176aeddf4",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/a/appstream/libappstream4_0.15.2-2_amd64.deb",
+			"version": "0.15.2-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libyaml-0-2_0.2.2-1build2_amd64",
+			"name": "libyaml-0-2",
+			"sha256": "b137d89a463b671383b6eaec404a494c8bd630a4adb79fc059c3aa48af170dcb",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/liby/libyaml/libyaml-0-2_0.2.2-1build2_amd64.deb",
+			"version": "0.2.2-1build2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libxmlb2_0.3.6-2build1_amd64",
+			"name": "libxmlb2",
+			"sha256": "8655f464923c47b4c727b5980a1d339ace1c4837f7be7b66fc6c16981f808a80",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/libx/libxmlb/libxmlb2_0.3.6-2build1_amd64.deb",
+			"version": "0.3.6-2build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libxml2_2.9.13-p-dfsg-1ubuntu0.4_amd64",
+			"name": "libxml2",
+			"sha256": "faf0c3cd6c94255df8d9a61f408a0c117a32394d154578643938884e410783cd",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/libx/libxml2/libxml2_2.9.13+dfsg-1ubuntu0.4_amd64.deb",
+			"version": "2.9.13+dfsg-1ubuntu0.4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libstemmer0d_2.2.0-1build1_amd64",
+			"name": "libstemmer0d",
+			"sha256": "a3aeda8dfd0fbee2322dce344f0128585c60455cef926d9ed53dbadde5c3111a",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/s/snowball/libstemmer0d_2.2.0-1build1_amd64.deb",
+			"version": "2.2.0-1build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "policykit-1_0.105-33_amd64",
+			"name": "policykit-1",
+			"sha256": "2b86cdff3f3c37357014dc19bcc404eb24e0b9ac91f046d3c1e80831872fac87",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/policykit-1/policykit-1_0.105-33_amd64.deb",
+			"version": "0.105-33"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "polkitd_0.105-33_amd64",
+			"name": "polkitd",
+			"sha256": "f604cc6654316cc257ade1bbd873f88ca4003afe43ed380e168c2d8c161847ad",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/policykit-1/polkitd_0.105-33_amd64.deb",
+			"version": "0.105-33"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpolkit-agent-1-0_0.105-33_amd64",
+			"name": "libpolkit-agent-1-0",
+			"sha256": "96f5382877b4fde82f7426524a0cd061171780adaa1dd18b8c437c38b4a16030",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/policykit-1/libpolkit-agent-1-0_0.105-33_amd64.deb",
+			"version": "0.105-33"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "pkexec_0.105-33_amd64",
+			"name": "pkexec",
+			"sha256": "93de931c86770fc864cc81f36cd17d577de0173080cf728cdf5b4dd2544b5443",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/policykit-1/pkexec_0.105-33_amd64.deb",
+			"version": "0.105-33"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libglib2.0-bin_2.72.4-0ubuntu2.3_amd64",
+			"name": "libglib2.0-bin",
+			"sha256": "71dfc39f9f779ca16db63a1f4034c6c969376f44a70a73af53ee23100de8d5d3",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/glib2.0/libglib2.0-bin_2.72.4-0ubuntu2.3_amd64.deb",
+			"version": "2.72.4-0ubuntu2.3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libglib2.0-data_2.72.4-0ubuntu2.3_amd64",
+			"name": "libglib2.0-data",
+			"sha256": "d73adeb284a344c6215ee4f4c12d9af4bebca05d843b9e7f378b568dcb1700d6",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/glib2.0/libglib2.0-data_2.72.4-0ubuntu2.3_all.deb",
+			"version": "2.72.4-0ubuntu2.3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "gir1.2-packagekitglib-1.0_1.2.5-2ubuntu2_amd64",
+			"name": "gir1.2-packagekitglib-1.0",
+			"sha256": "04f6e815f6c949330f7cf5a3bb0690e762e3b816087a8ff01ad11202d6574333",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/p/packagekit/gir1.2-packagekitglib-1.0_1.2.5-2ubuntu2_amd64.deb",
+			"version": "1.2.5-2ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libc6_2.35-0ubuntu3.8_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3.8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libgcc-s1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libgcc-s1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "gcc-12-base_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "gcc-12-base",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5build1_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5build1"
+				}
+			],
+			"key": "unzip_6.0-26ubuntu3.2_amd64",
+			"name": "unzip",
+			"sha256": "4f274ffc6774d52878322ef1e3eb6d185003e1607448e62893849825bfae347d",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/u/unzip/unzip_6.0-26ubuntu3.2_amd64.deb",
+			"version": "6.0-26ubuntu3.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libselinux1_3.3-1build2_amd64",
+					"name": "libselinux1",
+					"version": "3.3-1build2"
+				},
+				{
+					"key": "libpcre2-8-0_10.39-3ubuntu0.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.39-3ubuntu0.1"
+				},
+				{
+					"key": "libc6_2.35-0ubuntu3.8_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3.8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libgcc-s1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libgcc-s1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "gcc-12-base_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "gcc-12-base",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "libgmp10_2-6.2.1-p-dfsg-3ubuntu1_amd64",
+					"name": "libgmp10",
+					"version": "2:6.2.1+dfsg-3ubuntu1"
+				},
+				{
+					"key": "libattr1_1-2.5.1-1build1_amd64",
+					"name": "libattr1",
+					"version": "1:2.5.1-1build1"
+				},
+				{
+					"key": "libacl1_2.3.1-1_amd64",
+					"name": "libacl1",
+					"version": "2.3.1-1"
+				}
+			],
+			"key": "coreutils_8.32-4.1ubuntu1.2_amd64",
+			"name": "coreutils",
+			"sha256": "0353e860f0dcc3079c4cf9cb39bd878669cb6a113cd78ff2cb95a2d054822788",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/c/coreutils/coreutils_8.32-4.1ubuntu1.2_amd64.deb",
+			"version": "8.32-4.1ubuntu1.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libattr1_1-2.5.1-1build1_amd64",
+			"name": "libattr1",
+			"sha256": "bb4448dcade4f169846d6e3dc00b768f39afd16db07877f595a1d3d92d191050",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/a/attr/libattr1_2.5.1-1build1_amd64.deb",
+			"version": "1:2.5.1-1build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "debianutils_5.5-1ubuntu2_amd64",
+					"name": "debianutils",
+					"version": "5.5-1ubuntu2"
+				},
+				{
+					"key": "libc6_2.35-0ubuntu3.8_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3.8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libgcc-s1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libgcc-s1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "gcc-12-base_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "gcc-12-base",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "base-files_12ubuntu4.6_amd64",
+					"name": "base-files",
+					"version": "12ubuntu4.6"
+				},
+				{
+					"key": "libtinfo6_6.3-2ubuntu0.1_amd64",
+					"name": "libtinfo6",
+					"version": "6.3-2ubuntu0.1"
+				}
+			],
+			"key": "bash_5.1-6ubuntu1.1_amd64",
+			"name": "bash",
+			"sha256": "ada09ec56baa774af85b01ab8aad32f10ce82aeccbd2889110db318d46e26914",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/b/bash/bash_5.1-6ubuntu1.1_amd64.deb",
+			"version": "5.1-6ubuntu1.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "debianutils_5.5-1ubuntu2_amd64",
+			"name": "debianutils",
+			"sha256": "a285df5a72f6eadd75a042c148f4a26c6bead543e73077f12d8d0069b315082d",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/d/debianutils/debianutils_5.5-1ubuntu2_amd64.deb",
+			"version": "5.5-1ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "base-files_12ubuntu4.6_amd64",
+			"name": "base-files",
+			"sha256": "2bad1e15e08a1fb2b4efacf74151d1622adccac6479f5a25daf76bea6f210c7d",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/b/base-files/base-files_12ubuntu4.6_amd64.deb",
+			"version": "12ubuntu4.6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libc6_2.35-0ubuntu3.8_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3.8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libgcc-s1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libgcc-s1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "gcc-12-base_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "gcc-12-base",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "libjq1_1.6-2.1ubuntu3_amd64",
+					"name": "libjq1",
+					"version": "1.6-2.1ubuntu3"
+				},
+				{
+					"key": "libonig5_6.9.7.1-2build1_amd64",
+					"name": "libonig5",
+					"version": "6.9.7.1-2build1"
+				}
+			],
+			"key": "jq_1.6-2.1ubuntu3_amd64",
+			"name": "jq",
+			"sha256": "d7dd9f0441f1aea2e30e067e5fabbff96d4960b5d348de2c48fab90f37720224",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/j/jq/jq_1.6-2.1ubuntu3_amd64.deb",
+			"version": "1.6-2.1ubuntu3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libjq1_1.6-2.1ubuntu3_amd64",
+			"name": "libjq1",
+			"sha256": "4f43564b322b4314217d853deac93250f6b6dc2144c4f72d47bb2a6ffee55476",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/j/jq/libjq1_1.6-2.1ubuntu3_amd64.deb",
+			"version": "1.6-2.1ubuntu3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libonig5_6.9.7.1-2build1_amd64",
+			"name": "libonig5",
+			"sha256": "b02dbaa37b4ec7ad303cc8655b03a2a158299ce56fede9849e3bda501831f413",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/libo/libonig/libonig5_6.9.7.1-2build1_amd64.deb",
+			"version": "6.9.7.1-2build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libpcre3_2-8.39-13ubuntu0.22.04.1_amd64",
+					"name": "libpcre3",
+					"version": "2:8.39-13ubuntu0.22.04.1"
+				},
+				{
+					"key": "libc6_2.35-0ubuntu3.8_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3.8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libgcc-s1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libgcc-s1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "gcc-12-base_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "gcc-12-base",
+					"version": "12.3.0-1ubuntu1~22.04"
+				}
+			],
+			"key": "grep_3.7-1build1_amd64",
+			"name": "grep",
+			"sha256": "26d08b9c96962528c73c13b5c11f245b91e49edab15f73bf8705bad1472a0113",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/grep/grep_3.7-1build1_amd64.deb",
+			"version": "3.7-1build1"
 		}
 	],
 	"version": 1

--- a/images/actions-runner/apt.yaml
+++ b/images/actions-runner/apt.yaml
@@ -4,7 +4,7 @@
 #
 #  To generate the apt.lock.json run the following command
 #
-#     bazel run @ubuntu-jammy//:lock
+#     bazel run @ubuntu_jammy//:lock
 #
 # See deb_index at WORKSPACE.bazel
 version: 1
@@ -21,6 +21,27 @@ archs:
   - "amd64"
 
 packages:
+  # base
+  - "libc-bin"
+  - "ca-certificates"
+  # libs
+  - "libicu70"
+  - "libssl3"
+  - "libstdc++6"
+  - "tzdata"
+  - "zlib1g"
+  # packages
+  - "gcc"
   - "git"
   - "curl"
+  - "gawk"
   - "xz-utils"
+  - "sudo"
+  - "lsb-release"
+  - "gpg-agent"
+  - "software-properties-common"
+  - "unzip"
+  - "coreutils"
+  - "bash"
+  - "jq"
+  - "grep"

--- a/images/common/BUILD.bazel
+++ b/images/common/BUILD.bazel
@@ -1,0 +1,102 @@
+load("@aspect_bazel_lib//lib:tar.bzl", "tar")
+load("@rules_distroless//distroless:defs.bzl", "group", "home", "passwd")
+load(":variables.bzl", "MTIME", "NONROOT", "ROOT")
+
+package(default_visibility = ["//visibility:public"])
+
+tar(
+    name = "rootfs",
+    srcs = [],
+    args = [
+        "--format",
+        "gnutar",
+    ],
+    compress = "gzip",
+    mtree = ["./ type=dir uid=0 gid=0 time=0.0"],
+)
+
+tar(
+    name = "tmp",
+    srcs = [],
+    args = [
+        "--format",
+        "gnutar",
+    ],
+    compress = "gzip",
+    mtree = ["./tmp gname=root uname=root time=1501783453.0 mode=1777 gid=0 uid=0 type=dir"],
+)
+
+group(
+    name = "group",
+    entries = [
+        {
+            "name": "root",  # root_group
+            "gid": ROOT,
+            "password": "x",
+        },
+        {
+            "name": "tty",  # tty_group
+            "gid": 5,
+            "password": "x",
+        },
+        {
+            "name": "staff",  # staff_group
+            "gid": 50,
+            "password": "x",
+        },
+        {
+            "name": "nonroot",  # nonroot_group
+            "gid": NONROOT,
+            "password": "x",
+        },
+    ],
+    time = MTIME,
+)
+
+passwd(
+    name = "passwd",
+    entries = [
+        {
+            "gecos": ["root"],
+            "gid": ROOT,
+            "shell": "/sbin/nologin",
+            "home": "/root",
+            "uid": ROOT,
+            "password": "x",
+            "username": "root",
+        },
+        {
+            "gecos": ["nonroot"],
+            "gid": NONROOT,
+            "home": "/home/nonroot",
+            "shell": "/sbin/nologin",
+            "uid": NONROOT,
+            "password": "x",
+            "username": "nonroot",
+        },
+    ],
+)
+
+home(
+    name = "home",
+    dirs = [
+        {
+            "home": "/root",
+            "uid": ROOT,
+            "gid": ROOT,
+            "mode": 700,
+        },
+        {
+            "home": "/home",
+            "uid": ROOT,
+            "gid": ROOT,
+            "mode": 755,
+        },
+        {
+            "home": "/home/nonroot",
+            "uid": NONROOT,
+            "gid": NONROOT,
+            "mode": 700,
+        },
+    ],
+)

--- a/images/common/variables.bzl
+++ b/images/common/variables.bzl
@@ -1,0 +1,12 @@
+ARCHITECTURES = ["amd64"]
+DISTROS = ["debian12"]
+
+VERSIONS = [
+    ("debian11", "bullseye", "11"),  # deprecated
+    ("debian12", "bookworm", "12"),
+]
+
+NONROOT = 65532
+ROOT = 0
+
+MTIME = "946684800"

--- a/shell.nix
+++ b/shell.nix
@@ -18,4 +18,7 @@ pkgs.mkShell {
     pkgs.age
     pkgs.sops
   ];
+  shellHook = ''
+    export PATH="$HOME/.local/bin:$PATH"
+  '';
 }


### PR DESCRIPTION
Adding a few packages with Bazel on top of the existing regular image did not work properly - it broke paths, pkg configs, etc. So instead this PR recreates `ghcr.io/actions-runner` image from scratch with Bazel.