### PR TITLE
Adds missing dependencies to actions-runner

### DIFF
--- a/images/actions-runner/BUILD.bazel
+++ b/images/actions-runner/BUILD.bazel
@@ -206,7 +206,7 @@ oci_image(
 )
 
 oci_push(
-    name = "push_image",
+    name = "image.push",
     image = ":image",
     remote_tags = ["latest"],
     repository = "harbor.puqu.io/rszamszur/actions-runner",

--- a/images/actions-runner/BUILD.bazel
+++ b/images/actions-runner/BUILD.bazel
@@ -18,6 +18,7 @@ PACKAGES = [
     "@ubuntu_jammy//gawk",
     "@ubuntu_jammy//sed",
     "@ubuntu_jammy//curl",
+    "@ubuntu_jammy//tar",
     "@ubuntu_jammy//xz-utils",
     "@ubuntu_jammy//sudo",
     "@ubuntu_jammy//lsb-release",

--- a/images/actions-runner/BUILD.bazel
+++ b/images/actions-runner/BUILD.bazel
@@ -19,6 +19,7 @@ PACKAGES = [
     "@ubuntu_jammy//sed",
     "@ubuntu_jammy//curl",
     "@ubuntu_jammy//tar",
+    "@ubuntu_jammy//gzip",
     "@ubuntu_jammy//xz-utils",
     "@ubuntu_jammy//sudo",
     "@ubuntu_jammy//lsb-release",

--- a/images/actions-runner/BUILD.bazel
+++ b/images/actions-runner/BUILD.bazel
@@ -16,6 +16,7 @@ PACKAGES = [
     "@ubuntu_jammy//gcc",
     "@ubuntu_jammy//git",
     "@ubuntu_jammy//gawk",
+    "@ubuntu_jammy//sed",
     "@ubuntu_jammy//curl",
     "@ubuntu_jammy//xz-utils",
     "@ubuntu_jammy//sudo",

--- a/images/actions-runner/apt.lock.json
+++ b/images/actions-runner/apt.lock.json
@@ -1528,6 +1528,51 @@
 			"arch": "amd64",
 			"dependencies": [
 				{
+					"key": "libselinux1_3.3-1build2_amd64",
+					"name": "libselinux1",
+					"version": "3.3-1build2"
+				},
+				{
+					"key": "libpcre2-8-0_10.39-3ubuntu0.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.39-3ubuntu0.1"
+				},
+				{
+					"key": "libc6_2.35-0ubuntu3.8_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3.8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libgcc-s1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libgcc-s1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "gcc-12-base_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "gcc-12-base",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "libacl1_2.3.1-1_amd64",
+					"name": "libacl1",
+					"version": "2.3.1-1"
+				}
+			],
+			"key": "sed_4.8-1ubuntu2_amd64",
+			"name": "sed",
+			"sha256": "cb871eba3078dbfe67770e9b8c2087cf568f06769611360a7de293a806f266c5",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/s/sed/sed_4.8-1ubuntu2_amd64.deb",
+			"version": "4.8-1ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
 					"key": "liblzma5_5.2.5-2ubuntu1_amd64",
 					"name": "liblzma5",
 					"version": "5.2.5-2ubuntu1"

--- a/images/actions-runner/apt.lock.json
+++ b/images/actions-runner/apt.lock.json
@@ -954,7 +954,43 @@
 		},
 		{
 			"arch": "amd64",
-			"dependencies": [],
+			"dependencies": [
+				{
+					"key": "libselinux1_3.3-1build2_amd64",
+					"name": "libselinux1",
+					"version": "3.3-1build2"
+				},
+				{
+					"key": "libpcre2-8-0_10.39-3ubuntu0.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.39-3ubuntu0.1"
+				},
+				{
+					"key": "libc6_2.35-0ubuntu3.8_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3.8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libgcc-s1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libgcc-s1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "gcc-12-base_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "gcc-12-base",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "libacl1_2.3.1-1_amd64",
+					"name": "libacl1",
+					"version": "2.3.1-1"
+				}
+			],
 			"key": "tar_1.34-p-dfsg-1ubuntu0.1.22.04.2_amd64",
 			"name": "tar",
 			"sha256": "151e3a61137aeb04cd714656852877a00d47d918246806f9e5b08d1cef32b816",

--- a/images/actions-runner/apt.lock.json
+++ b/images/actions-runner/apt.lock.json
@@ -1468,6 +1468,36 @@
 			"arch": "amd64",
 			"dependencies": [
 				{
+					"key": "libc6_2.35-0ubuntu3.8_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3.8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libgcc-s1_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "libgcc-s1",
+					"version": "12.3.0-1ubuntu1~22.04"
+				},
+				{
+					"key": "gcc-12-base_12.3.0-1ubuntu1_22.04_amd64",
+					"name": "gcc-12-base",
+					"version": "12.3.0-1ubuntu1~22.04"
+				}
+			],
+			"key": "gzip_1.10-4ubuntu4.1_amd64",
+			"name": "gzip",
+			"sha256": "7f1bbc6e8db8549417c9438b10f4db06c5aebfaa5be9b3d13e7ebff2de2a9d9d",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240901T030400Z/pool/main/g/gzip/gzip_1.10-4ubuntu4.1_amd64.deb",
+			"version": "1.10-4ubuntu4.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
 					"key": "libsigsegv2_2.13-1ubuntu3_amd64",
 					"name": "libsigsegv2",
 					"version": "2.13-1ubuntu3"

--- a/images/actions-runner/apt.yaml
+++ b/images/actions-runner/apt.yaml
@@ -35,6 +35,7 @@ packages:
   - "git"
   - "curl"
   - "tar"
+  - "gzip"
   - "gawk"
   - "sed"
   - "xz-utils"

--- a/images/actions-runner/apt.yaml
+++ b/images/actions-runner/apt.yaml
@@ -35,6 +35,7 @@ packages:
   - "git"
   - "curl"
   - "gawk"
+  - "sed"
   - "xz-utils"
   - "sudo"
   - "lsb-release"

--- a/images/actions-runner/apt.yaml
+++ b/images/actions-runner/apt.yaml
@@ -34,6 +34,7 @@ packages:
   - "gcc"
   - "git"
   - "curl"
+  - "tar"
   - "gawk"
   - "sed"
   - "xz-utils"


### PR DESCRIPTION
`tar` and `gzip` is an GH actions-runner runtime dependency:
![image](https://github.com/user-attachments/assets/d46df361-e035-478b-8a42-84a737f9a0b9)

`sed` is required for `image.push` target

```shell
runner@pve-talos-wwggv-runner-cg4wx:~$ git clone https://github.com/rszamszur/home-ops.git
Cloning into 'home-ops'...
remote: Enumerating objects: 3654, done.
remote: Counting objects: 100% (445/445), done.
remote: Compressing objects: 100% (208/208), done.
remote: Total 3654 (delta 311), reused 249 (delta 235), pack-reused 3209 (from 2)
Receiving objects: 100% (3654/3654), 21.16 MiB | 15.98 MiB/s, done.
Resolving deltas: 100% (2111/2111), done.
runner@pve-talos-wwggv-runner-cg4wx:~$ cd home-ops/
runner@pve-talos-wwggv-runner-cg4wx:~/home-ops$ bazel run //images/actions-runner:push_image
2025/05/31 19:00:10 Downloading https://releases.bazel.build/7.6.1/release/bazel-7.6.1-linux-x86_64...
Downloading: 54 MB out of 54 MB (100%)
Extracting Bazel installation...
Starting local Bazel server and connecting to it...
INFO: Streaming build results to: https://buildbuddy.szamszur.cloud/invocation/9877ea17-3e41-4163-ba10-a25a1895e2a8
WARNING: Download from https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/1.1.0/rules_pkg-1.1.0.tar.gz failed: class java.io.FileNotFoundException GET returned 404 Not Found
INFO: Analyzed target //images/actions-runner:push_image (485 packages loaded, 8932 targets configured).
INFO: From Tar images/actions-runner/runner-group.tar.gz:
tar: Ignoring previous option 'gzip:!timestamp', separate multiple options with commas
INFO: From Tar images/actions-runner/runner-home.tar.gz:
tar: Ignoring previous option 'gzip:!timestamp', separate multiple options with commas
INFO: From Tar images/actions-runner/runner-passwd.tar.gz:
tar: Ignoring previous option 'gzip:!timestamp', separate multiple options with commas
ERROR: /home/runner/home-ops/images/actions-runner/BUILD.bazel:132:7: Action images/actions-runner/locale.tar.gz failed: (Exit 127): locale.sh failed: error executing Action command (from target //images/actions-runner:locale) external/rules_distroless/distroless/private/locale.sh external/bsd_tar_linux_amd64/tar bazel-out/k8-fastbuild/bin/images/actions-runner/locale.tar.gz ... (remaining 18 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
external/rules_distroless/distroless/private/locale.sh: line 17: sed: command not found
tar: Write error
tar: Error exit delayed from previous errors.
Target //images/actions-runner:push_image failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 41.753s, Critical Path: 1.16s
INFO: 236 processes: 38 internal, 198 processwrapper-sandbox.
ERROR: Build did NOT complete successfully
ERROR: Build failed. Not running target
INFO: Streaming build results to: https://buildbuddy.szamszur.cloud/invocation/9877ea17-3e41-4163-ba10-a25a1895e2a8
```